### PR TITLE
refactor: use rg module output for dev

### DIFF
--- a/platform/infra/envs/dev/main.tf
+++ b/platform/infra/envs/dev/main.tf
@@ -11,7 +11,7 @@ module "acr" {
   count               = var.enable_acr ? 1 : 0
   source              = "../../Azure/modules/acr"
   name                = "${var.project_name}-${var.env_name}-acr"
-  resource_group_name = var.deploy_rg
+  resource_group_name = module.rg.name
   location            = var.location
   sku                 = var.acr_sku
   tags                = var.tags
@@ -21,7 +21,7 @@ module "aks" {
   count               = var.enable_aks ? 1 : 0
   source              = "../../Azure/modules/aks"
   name                = "${var.project_name}-${var.env_name}-aks"
-  resource_group_name = var.deploy_rg
+  resource_group_name = module.rg.name
   location            = var.location
   node_count          = var.aks_node_count
   vm_size             = var.aks_vm_size
@@ -33,7 +33,7 @@ module "sql" {
   source                        = "../../Azure/modules/sql-database"
   server_name                   = "${var.project_name}-${var.env_name}-sqlsrv"
   db_name                       = var.sql_db_name
-  resource_group_name           = var.deploy_rg
+  resource_group_name           = module.rg.name
   location                      = var.location
   admin_login                   = var.sql_admin_login
   admin_password                = var.sql_admin_password
@@ -52,7 +52,7 @@ module "aad_app" {
 module "kv" {
   source                        = "../../Azure/modules/key-vault"
   name                          = "${var.project_name}-${var.env_name}-kv"
-  resource_group_name           = var.deploy_rg
+  resource_group_name           = module.rg.name
   location                      = var.location
   public_network_access_enabled = var.kv_public_network_access
   tags                          = var.tags
@@ -71,7 +71,7 @@ module "func_cron" {
   source                         = "../../Azure/modules/function-app"
   name                           = "${var.project_name}-${var.env_name}-func-cron"
   plan_name                      = "${var.project_name}-${var.env_name}-asp"
-  resource_group_name            = var.deploy_rg
+  resource_group_name            = module.rg.name
   location                       = var.location
   plan_sku                       = var.func_plan_sku
   runtime                        = var.function_cron_runtime
@@ -83,7 +83,7 @@ module "func_external" {
   source                         = "../../Azure/modules/function-app"
   name                           = "${var.project_name}-${var.env_name}-func-ext"
   plan_name                      = "${var.project_name}-${var.env_name}-asp"
-  resource_group_name            = var.deploy_rg
+  resource_group_name            = module.rg.name
   location                       = var.location
   plan_sku                       = var.func_plan_sku
   runtime                        = var.function_external_runtime
@@ -95,7 +95,7 @@ module "web" {
   source                         = "../../Azure/modules/app-service-web"
   name                           = "${var.project_name}-${var.env_name}-web"
   plan_name                      = "${var.project_name}-${var.env_name}-asp"
-  resource_group_name            = var.deploy_rg
+  resource_group_name            = module.rg.name
   location                       = var.location
   plan_sku                       = var.web_plan_sku
   dotnet_version                 = var.web_dotnet_version
@@ -107,7 +107,7 @@ module "storage_data" {
   count               = var.enable_storage ? 1 : 0
   source              = "../../Azure/modules/storage-account"
   name                = "${var.project_name}${var.env_name}data"
-  resource_group_name = var.deploy_rg
+  resource_group_name = module.rg.name
   location            = var.location
   tags                = var.tags
 }

--- a/platform/infra/envs/dev/terraform.tfvars
+++ b/platform/infra/envs/dev/terraform.tfvars
@@ -10,8 +10,6 @@ storage_account_name = "deveus2terraform"
 key                 = "arbit/dev.tfstate"
 use_azuread_auth    = true
 
-deploy_rg = "arbit-dev-rg"
-
 app_insights_name             = "arbit-dev-appi"
 app_insights_rg               = "arbit-dev-rg"
 app_insights_connection_string = "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://example.com/"

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -51,11 +51,6 @@ variable "tenant_id" {
   type        = string
 }
 
-variable "deploy_rg" {
-  type        = string
-  description = "Resource Group name"
-}
-
 variable "app_insights_connection_string" {
   type        = string
   description = "App Insights connection string"


### PR DESCRIPTION
## Summary
- reference `module.rg.name` for resource group in dev modules
- drop unused `deploy_rg` variable and tfvars entry

## Testing
- `terraform fmt platform/infra/envs/dev/main.tf` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c470cdd2c88326a4f1928924f2d1a1