### PR TITLE
refactor: share service plan

### DIFF
--- a/platform/infra/Azure/modules/app-service-web/main.tf
+++ b/platform/infra/Azure/modules/app-service-web/main.tf
@@ -1,16 +1,8 @@
-resource "azurerm_service_plan" "plan" {
-  name                = var.plan_name
-  location            = var.location
-  resource_group_name = var.resource_group_name
-  os_type             = "Linux"
-  sku_name            = var.plan_sku
-  tags                = var.tags
-}
 resource "azurerm_linux_web_app" "app" {
   name                = var.name
   resource_group_name = var.resource_group_name
   location            = var.location
-  service_plan_id     = azurerm_service_plan.plan.id
+  service_plan_id     = var.service_plan_id
   https_only          = true
   identity { type = "SystemAssigned" }
   site_config {

--- a/platform/infra/Azure/modules/app-service-web/variables.tf
+++ b/platform/infra/Azure/modules/app-service-web/variables.tf
@@ -1,11 +1,7 @@
 variable "name"                           { type = string }
-variable "plan_name"                      { type = string }
 variable "resource_group_name"            { type = string }
 variable "location"                       { type = string }
-variable "plan_sku" {
-  type    = string
-  default = "B1"
-}
+variable "service_plan_id"               { type = string }
 variable "dotnet_version" {
   type    = string
   default = "8.0"

--- a/platform/infra/Azure/modules/function-app/main.tf
+++ b/platform/infra/Azure/modules/function-app/main.tf
@@ -14,19 +14,11 @@ resource "azurerm_storage_account" "sa" {
   min_tls_version          = "TLS1_2"
   tags                     = var.tags
 }
-resource "azurerm_service_plan" "plan" {
-  name                = var.plan_name
-  location            = var.location
-  resource_group_name = var.resource_group_name
-  os_type             = "Linux"
-  sku_name            = var.plan_sku
-  tags                = var.tags
-}
 resource "azurerm_linux_function_app" "func" {
   name                        = var.name
   resource_group_name         = var.resource_group_name
   location                    = var.location
-  service_plan_id             = azurerm_service_plan.plan.id
+  service_plan_id             = var.service_plan_id
   storage_account_name        = azurerm_storage_account.sa.name
   storage_account_access_key  = azurerm_storage_account.sa.primary_access_key
   https_only                  = true

--- a/platform/infra/Azure/modules/function-app/variables.tf
+++ b/platform/infra/Azure/modules/function-app/variables.tf
@@ -1,11 +1,7 @@
 variable "name"                           { type = string }
-variable "plan_name"                      { type = string }
 variable "resource_group_name"            { type = string }
 variable "location"                       { type = string }
-variable "plan_sku" {
-  type    = string
-  default = "Y1"
-}
+variable "service_plan_id"               { type = string }
 variable "runtime" {
   type    = string
   default = "dotnet"

--- a/platform/infra/Azure/modules/service-plan/main.tf
+++ b/platform/infra/Azure/modules/service-plan/main.tf
@@ -1,0 +1,8 @@
+resource "azurerm_service_plan" "plan" {
+  name                = var.name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  os_type             = var.os_type
+  sku_name            = var.sku
+  tags                = var.tags
+}

--- a/platform/infra/Azure/modules/service-plan/outputs.tf
+++ b/platform/infra/Azure/modules/service-plan/outputs.tf
@@ -1,0 +1,3 @@
+output "id" {
+  value = azurerm_service_plan.plan.id
+}

--- a/platform/infra/Azure/modules/service-plan/variables.tf
+++ b/platform/infra/Azure/modules/service-plan/variables.tf
@@ -1,0 +1,25 @@
+variable "name" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "resource_group_name" {
+  type = string
+}
+
+variable "sku" {
+  type = string
+}
+
+variable "os_type" {
+  type    = string
+  default = "Linux"
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/platform/infra/envs/dev/main.tf
+++ b/platform/infra/envs/dev/main.tf
@@ -67,13 +67,21 @@ module "logs" {
   tags                = var.tags
 }
 
+module "service_plan" {
+  source              = "../../Azure/modules/service-plan"
+  name                = "${var.project_name}-${var.env_name}-asp"
+  resource_group_name = var.deploy_rg
+  location            = var.location
+  sku                 = var.plan_sku
+  tags                = var.tags
+}
+
 module "func_cron" {
   source                         = "../../Azure/modules/function-app"
   name                           = "${var.project_name}-${var.env_name}-func-cron"
-  plan_name                      = "${var.project_name}-${var.env_name}-asp"
   resource_group_name            = var.deploy_rg
   location                       = var.location
-  plan_sku                       = var.func_plan_sku
+  service_plan_id                = module.service_plan.id
   runtime                        = var.function_cron_runtime
   app_insights_connection_string = var.app_insights_connection_string
   tags                           = var.tags
@@ -82,10 +90,9 @@ module "func_cron" {
 module "func_external" {
   source                         = "../../Azure/modules/function-app"
   name                           = "${var.project_name}-${var.env_name}-func-ext"
-  plan_name                      = "${var.project_name}-${var.env_name}-asp"
   resource_group_name            = var.deploy_rg
   location                       = var.location
-  plan_sku                       = var.func_plan_sku
+  service_plan_id                = module.service_plan.id
   runtime                        = var.function_external_runtime
   app_insights_connection_string = var.app_insights_connection_string
   tags                           = var.tags
@@ -94,10 +101,9 @@ module "func_external" {
 module "web" {
   source                         = "../../Azure/modules/app-service-web"
   name                           = "${var.project_name}-${var.env_name}-web"
-  plan_name                      = "${var.project_name}-${var.env_name}-asp"
   resource_group_name            = var.deploy_rg
   location                       = var.location
-  plan_sku                       = var.web_plan_sku
+  service_plan_id                = module.service_plan.id
   dotnet_version                 = var.web_dotnet_version
   app_insights_connection_string = var.app_insights_connection_string
   tags                           = var.tags
@@ -110,4 +116,8 @@ module "storage_data" {
   resource_group_name = var.deploy_rg
   location            = var.location
   tags                = var.tags
+}
+
+output "service_plan_id" {
+  value = module.service_plan.id
 }

--- a/platform/infra/envs/dev/terraform.tfvars
+++ b/platform/infra/envs/dev/terraform.tfvars
@@ -31,8 +31,7 @@ kv_public_network_access = true
 acr_sku        = "Basic"
 aks_node_count = 1
 aks_vm_size    = "Standard_DS2_v2"
-web_plan_sku   = "B1"
-func_plan_sku  = "Y1"
+plan_sku       = "B1"
 
 web_dotnet_version        = "8.0"
 function_external_runtime = "dotnet"

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -125,16 +125,10 @@ variable "aks_vm_size" {
   default     = "Standard_DS2_v2"
 }
 
-variable "web_plan_sku" {
+variable "plan_sku" {
   type        = string
   description = "App Service plan SKU"
   default     = "B1"
-}
-
-variable "func_plan_sku" {
-  type        = string
-  description = "Function App plan SKU"
-  default     = "Y1"
 }
 
 variable "web_dotnet_version" {

--- a/platform/infra/envs/prod/terraform.tfvars
+++ b/platform/infra/envs/prod/terraform.tfvars
@@ -17,8 +17,7 @@ kv_public_network_access = true
 acr_sku        = "Premium"
 aks_node_count = 3
 aks_vm_size    = "Standard_DS3_v2"
-web_plan_sku   = "P1v3"
-func_plan_sku  = "Y1"
+plan_sku       = "P1v3"
 
 web_dotnet_version        = "8.0"
 function_external_runtime = "dotnet"

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -50,3 +50,9 @@ variable "tenant_id" {
   description = "Azure Tenant ID"
   type        = string
 }
+
+variable "plan_sku" {
+  type        = string
+  description = "App Service plan SKU"
+  default     = "B1"
+}

--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -17,8 +17,7 @@ kv_public_network_access = true
 acr_sku        = "Standard"
 aks_node_count = 2
 aks_vm_size    = "Standard_DS3_v2"
-web_plan_sku   = "P1v3"
-func_plan_sku  = "Y1"
+plan_sku       = "P1v3"
 
 web_dotnet_version        = "8.0"
 function_external_runtime = "dotnet"

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -50,3 +50,9 @@ variable "tenant_id" {
   description = "Azure Tenant ID"
   type        = string
 }
+
+variable "plan_sku" {
+  type        = string
+  description = "App Service plan SKU"
+  default     = "B1"
+}


### PR DESCRIPTION
## Summary
- add reusable service plan module and expose its id
- use shared plan id in function-app and app-service-web modules
- wire environments to shared plan and output its id

## Testing
- `terraform fmt -recursive` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `wget https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_amd64.zip -O /tmp/terraform.zip` *(fails: proxy forbids connection)*

------
https://chatgpt.com/codex/tasks/task_e_68c470c14c888326ad6fc92ecd24ffd9