### PR TITLE
chore: align env backend and config

### DIFF
--- a/platform/infra/envs/prod/backend.tfvars
+++ b/platform/infra/envs/prod/backend.tfvars
@@ -4,3 +4,5 @@ storage_account_name = "prodeus2terraform"
 container_name       = "arbit"
 key                  = "arbit/prod.tfstate"
 use_azuread_auth     = true
+subscription_id = "930755b1-ef22-4721-a31a-1b6fbecf7da6"
+tenant_id       = "70750cc4-6f21-4c27-bb0e-8b7e66bcb2dd"

--- a/platform/infra/envs/prod/terraform.tfvars
+++ b/platform/infra/envs/prod/terraform.tfvars
@@ -1,6 +1,8 @@
 project_name = "arbit"
 location     = "eastus"
 env_name = "prod"
+subscription_id = "930755b1-ef22-4721-a31a-1b6fbecf7da6"
+tenant_id       = "70750cc4-6f21-4c27-bb0e-8b7e66bcb2dd"
 
 tags = {
   project = "arbit"

--- a/platform/infra/envs/stage/backend.tfvars
+++ b/platform/infra/envs/stage/backend.tfvars
@@ -1,6 +1,8 @@
 
-resource_group_name  = "stag-eus2-ops-rg-1"
-storage_account_name = "stageeus2terraform"
+resource_group_name  = "staging-eus2-ops-rg-1"
+storage_account_name = "stagingeeus2terraform"
 container_name       = "arbit"
 key                  = "arbit/stage.tfstate"
 use_azuread_auth     = true
+subscription_id = "930755b1-ef22-4721-a31a-1b6fbecf7da6"
+tenant_id       = "70750cc4-6f21-4c27-bb0e-8b7e66bcb2dd"

--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -1,6 +1,8 @@
 project_name = "arbit"
 location     = "eastus"
 env_name = "stage"
+subscription_id = "930755b1-ef22-4721-a31a-1b6fbecf7da6"
+tenant_id       = "70750cc4-6f21-4c27-bb0e-8b7e66bcb2dd"
 
 tags = {
   project = "arbit"


### PR DESCRIPTION
## Summary
- align stage backend storage resources with staging convention
- add subscription and tenant IDs to prod and stage terraform configs

## Testing
- `terraform fmt -recursive` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68c82bb1b8508326ab7b209091fb9355