### PR TITLE
Update stage backend storage account configuration

### DIFF
--- a/platform/infra/envs/stage/backend.tfvars
+++ b/platform/infra/envs/stage/backend.tfvars
@@ -1,6 +1,6 @@
 
 resource_group_name  = "staging-eus2-ops-rg-1"
-storage_account_name = "stagingeeus2terraform"
+storage_account_name = "deveus2terraform"
 container_name       = "arbit"
 key                  = "arbit/stage.tfstate"
 use_azuread_auth     = true


### PR DESCRIPTION
## Summary
- update the stage backend configuration to use the deveus2terraform storage account

## Testing
- terraform init -backend-config=backend.tfvars *(fails: `terraform` command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8307e54b48326bd64bc65690f5061