### PR TITLE
Add SQL firewall rules and enable SQL module in env configs

### DIFF
--- a/platform/infra/envs/dev/terraform.tfvars
+++ b/platform/infra/envs/dev/terraform.tfvars
@@ -17,7 +17,7 @@ tags = {
 enable_aks = false
 enable_acr = false
 enable_storage = false
-enable_sql = false
+enable_sql = true
 kv_public_network_access = true
 
 acr_sku = "Basic"
@@ -35,5 +35,12 @@ sql_sku_name = "GP_S_Gen5_2"
 sql_auto_pause_minutes = 60
 sql_max_size_gb = 32
 sql_public_network_access = true
+sql_firewall_rules = [
+  {
+    name             = "allow-any-sql"
+    start_ip_address = "0.0.0.0"
+    end_ip_address   = "255.255.255.255"
+  }
+]
 sql_admin_login = "sqladmin"
 sql_admin_password = "P@ssw0rd1234!"

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -154,6 +154,14 @@ variable "sql_public_network_access" {
   default     = true
 }
 
+variable "sql_firewall_rules" {
+  type = list(object({
+    name             = string
+    start_ip_address = string
+    end_ip_address   = string
+  }))
+}
+
 variable "sql_admin_login" {
   type        = string
   description = "SQL administrator login"

--- a/platform/infra/envs/prod/terraform.tfvars
+++ b/platform/infra/envs/prod/terraform.tfvars
@@ -13,7 +13,7 @@ tags = {
 enable_aks      = false
 enable_acr      = false
 enable_storage  = false
-enable_sql      = false
+enable_sql      = true
 kv_public_network_access = true
 
 acr_sku        = "Premium"
@@ -31,5 +31,12 @@ sql_sku_name              = "GP_S_Gen5_2"
 sql_auto_pause_minutes    = 60
 sql_max_size_gb           = 32
 sql_public_network_access = true
+sql_firewall_rules = [
+  {
+    name             = "allow-any-sql"
+    start_ip_address = "0.0.0.0"
+    end_ip_address   = "255.255.255.255"
+  }
+]
 # sql_admin_login    = ""
 # sql_admin_password = ""

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -50,3 +50,11 @@ variable "tenant_id" {
   description = "Azure Tenant ID"
   type        = string
 }
+
+variable "sql_firewall_rules" {
+  type = list(object({
+    name             = string
+    start_ip_address = string
+    end_ip_address   = string
+  }))
+}

--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -13,7 +13,7 @@ tags = {
 enable_aks      = false
 enable_acr      = false
 enable_storage  = false
-enable_sql      = false
+enable_sql      = true
 kv_public_network_access = true
 
 acr_sku        = "Standard"
@@ -31,5 +31,12 @@ sql_sku_name              = "GP_S_Gen5_2"
 sql_auto_pause_minutes    = 60
 sql_max_size_gb           = 32
 sql_public_network_access = true
+sql_firewall_rules = [
+  {
+    name             = "allow-any-sql"
+    start_ip_address = "0.0.0.0"
+    end_ip_address   = "255.255.255.255"
+  }
+]
 # sql_admin_login    = ""
 # sql_admin_password = ""

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -50,3 +50,11 @@ variable "tenant_id" {
   description = "Azure Tenant ID"
   type        = string
 }
+
+variable "sql_firewall_rules" {
+  type = list(object({
+    name             = string
+    start_ip_address = string
+    end_ip_address   = string
+  }))
+}


### PR DESCRIPTION
## Summary
- declare the sql_firewall_rules variable in each environment configuration
- enable SQL deployments and configure an allow-all firewall rule in every environment tfvars file

## Testing
- terraform plan (dev) *(fails: terraform CLI is not available in the execution environment)*
- terraform plan (stage) *(fails: terraform CLI is not available in the execution environment)*
- terraform plan (prod) *(fails: terraform CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8361d8b388326884c9fdbafa5ed22