### PR TITLE
Configure SQL firewall rules for all environments

### DIFF
--- a/platform/infra/envs/dev/terraform.tfvars
+++ b/platform/infra/envs/dev/terraform.tfvars
@@ -17,7 +17,7 @@ tags = {
 enable_aks = false
 enable_acr = false
 enable_storage = false
-enable_sql = false
+enable_sql = true
 kv_public_network_access = true
 
 acr_sku = "Basic"
@@ -37,3 +37,11 @@ sql_max_size_gb = 32
 sql_public_network_access = true
 sql_admin_login = "sqladmin"
 sql_admin_password = "P@ssw0rd1234!"
+
+sql_firewall_rules = [
+  {
+    name             = "allow-any-sql"
+    start_ip_address = "0.0.0.0"
+    end_ip_address   = "255.255.255.255"
+  }
+]

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -166,3 +166,11 @@ variable "sql_admin_password" {
   default     = ""
   sensitive   = true
 }
+
+variable "sql_firewall_rules" {
+  type = list(object({
+    name             = string
+    start_ip_address = string
+    end_ip_address   = string
+  }))
+}

--- a/platform/infra/envs/prod/terraform.tfvars
+++ b/platform/infra/envs/prod/terraform.tfvars
@@ -13,7 +13,7 @@ tags = {
 enable_aks      = false
 enable_acr      = false
 enable_storage  = false
-enable_sql      = false
+enable_sql      = true
 kv_public_network_access = true
 
 acr_sku        = "Premium"
@@ -33,3 +33,11 @@ sql_max_size_gb           = 32
 sql_public_network_access = true
 # sql_admin_login    = ""
 # sql_admin_password = ""
+
+sql_firewall_rules = [
+  {
+    name             = "allow-any-sql"
+    start_ip_address = "0.0.0.0"
+    end_ip_address   = "255.255.255.255"
+  }
+]

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -50,3 +50,11 @@ variable "tenant_id" {
   description = "Azure Tenant ID"
   type        = string
 }
+
+variable "sql_firewall_rules" {
+  type = list(object({
+    name             = string
+    start_ip_address = string
+    end_ip_address   = string
+  }))
+}

--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -13,7 +13,7 @@ tags = {
 enable_aks      = false
 enable_acr      = false
 enable_storage  = false
-enable_sql      = false
+enable_sql      = true
 kv_public_network_access = true
 
 acr_sku        = "Standard"
@@ -33,3 +33,11 @@ sql_max_size_gb           = 32
 sql_public_network_access = true
 # sql_admin_login    = ""
 # sql_admin_password = ""
+
+sql_firewall_rules = [
+  {
+    name             = "allow-any-sql"
+    start_ip_address = "0.0.0.0"
+    end_ip_address   = "255.255.255.255"
+  }
+]

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -50,3 +50,11 @@ variable "tenant_id" {
   description = "Azure Tenant ID"
   type        = string
 }
+
+variable "sql_firewall_rules" {
+  type = list(object({
+    name             = string
+    start_ip_address = string
+    end_ip_address   = string
+  }))
+}


### PR DESCRIPTION
## Summary
- add sql_firewall_rules variable declarations for dev, stage, and prod environments
- enable the SQL module and define an allow-all firewall rule in each environment tfvars file

## Testing
- not run (terraform CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c8360b634c83268f9d5e42d9da6e3e