### PR TITLE
Sanitize arbitration configuration secrets

### DIFF
--- a/Arbitration/MPArbitration/appsettings.json
+++ b/Arbitration/MPArbitration/appsettings.json
@@ -1,9 +1,9 @@
 {
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",
-    "ClientId": "",
-    "TenantId": "2e09f3a3-0520-461f-8474-052a8ed7814a",
-    "Audience": "",
+    "ClientId": "@Microsoft.KeyVault(SecretName=mp-arbitration-azuread-client-id)",
+    "TenantId": "@Microsoft.KeyVault(SecretName=mp-arbitration-azuread-tenant-id)",
+    "Audience": "@Microsoft.KeyVault(SecretName=mp-arbitration-azuread-audience)",
     "CallbackPath": "/signin-oidc"
   },
   "Logging": {
@@ -13,30 +13,28 @@
       "Microsoft.Hosting.Lifetime": "Information"
     },
     "ApplicationInsights": {
-      "ConnectionString": "InstrumentationKey=ba28e030-ca40-4a77-bd4a-849970be0acf;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=f2113104-a7f1-457b-866f-f8ec969272e8",
+      "ConnectionString": "@Microsoft.KeyVault(SecretName=mp-arbitration-appinsights-connection-string)",
       "LogLevel": {
         "Default": "Information"
       }
     }
   },
   "ConnectionStrings": {
-
-    "ConnStr": "Server=TCP:DE-dwsql13-sql.database.windows.net,1433;Initial Catalog=dE-HaloArbit-db;Persist Security Info=False;User ID=arbitration-calculator-appuser;Password=6wD0AD^zsU8X*92yzf12MHm0Pc;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=60",
-    "IDRConnStr": "Data Source=DE-DWSQL21-VM;Database=SRC_IDRSupport;Integrated Security=false;User ID=arbitapp_SRC_IDRSupport-appuser;Password=&g$Sjatf8i0TbZNZq55Z4a;MultipleActiveResultSets=True;Encrypt=False;TrustServerCertificate=True;Connection Timeout=30"
-
+    "ConnStr": "@Microsoft.KeyVault(SecretName=mp-arbitration-sql-connection-string)",
+    "IDRConnStr": "@Microsoft.KeyVault(SecretName=mp-arbitration-idr-connection-string)"
   },
   "Storage": {
-    "Connection": "DefaultEndpointsProtocol=https;AccountName=DeHaloArbitSA;AccountKey=t+RR4NsL/UiAoc79a5dw8DAgxXi+H7x2Z7i983uFVrwaKMEBoKGnhzQ8y4aYB+EskmgdKHki6UQs+AStKh6DZg==;EndpointSuffix=core.windows.net",
+    "Connection": "@Microsoft.KeyVault(SecretName=mp-arbitration-storage-connection-string)",
     "Container": "arbitration-calculator"
   },
   "AllowedHosts": "*",
-  "ApiKey": "738738278372140731047310294701239749012374901237",
+  "ApiKey": "@Microsoft.KeyVault(SecretName=mp-arbitration-api-key)",
   "DEFAULT_PAYOR_JSON": "{}",
   "DEFAULT_ENTITY_ADDRESS": "1141 N Loop 1604 E #105-612",
   "DEFAULT_ENTITY_CITY": "San Antonio",
   "DEFAULT_ENTITY_STATE": "TX",
   "DEFAULT_ENTITY_ZIP": "78332",
-  "SendGridApiKey": "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",
-  "FromAddress": "NoReply@HaloMD.com",
-  "ReplyToAddress": "NoReply@HaloMD.com"
+  "SendGridApiKey": "@Microsoft.KeyVault(SecretName=mp-arbitration-sendgrid-api-key)",
+  "FromAddress": "@Microsoft.KeyVault(SecretName=mp-arbitration-from-address)",
+  "ReplyToAddress": "@Microsoft.KeyVault(SecretName=mp-arbitration-replyto-address)"
 }

--- a/Arbitration/MPNotify/App.config
+++ b/Arbitration/MPNotify/App.config
@@ -1,29 +1,29 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-	<appSettings>
-		<!-- DEV settings arbitrationpoccalculator.azurewebsites.net  -->
-		<add key="baseAppAddress" value="https://localhost:44473/"/>
-		<add key="client_id" value="e6ddd06c-eb88-47fb-8579-185b2436a2cb"/>
-		<add key="clientSecret" value="5oM8Q~VEx8VkLW6srlm2Fexz.h5Tb9x3fIU9xbnn"/>
-		<add key="resource" value="api://e6ddd06c-eb88-47fb-8579-185b2436a2cb"/>
-		<add key="tenant_id" value="2e09f3a3-0520-461f-8474-052a8ed7814a"/>
-		
-		
-		<!-- PROD settings only -->
-		<!--<add key="baseAppAddress" value="https://arbitration.mpowerhealth.com/"/>
-		<add key="client_id" value="feb1fc35-5267-4946-bc23-d8da34237e90"/>
-		<add key="clientSecret" value="Org8Q~bxeEhNjy4plCIJ~k1AMqM.ZEWjVn21sbEu"/>
-		<add key="secret_id" value="da638a1a-e40b-4376-b165-a00f76a22071"/> 
-		<add key="resource" value="api://feb1fc35-5267-4946-bc23-d8da34237e90"/>
-		<add key="tenant_id" value="2e09f3a3-0520-461f-8474-052a8ed7814a"/>-->
+  <appSettings>
+    <!-- DEV settings -->
+    <add key="baseAppAddress" value="https://localhost:44473/" />
+    <add key="client_id" value="@Microsoft.KeyVault(SecretName=mpnotify-dev-client-id)" />
+    <add key="clientSecret" value="@Microsoft.KeyVault(SecretName=mpnotify-dev-client-secret)" />
+    <add key="resource" value="@Microsoft.KeyVault(SecretName=mpnotify-dev-resource)" />
+    <add key="tenant_id" value="@Microsoft.KeyVault(SecretName=mpnotify-dev-tenant-id)" />
 
-		
-		<!-- EmailFromAddress - the authorized sender address as specified in SendGrid -->
-		<add key="EmailFromAddress" value="nsa@halomd.com"/>
-		<add key="EmailFromName" value="HaloMD IDR"/>
-		<!--The access key for SendGrid -->
-		<add key="SendGridApiKey" value="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" />
-		<!-- Other settings -->
-		<add key="daysToKeepLogFiles" value="30"/>
-	</appSettings>
+    <!-- PROD settings retrieved via Key Vault -->
+    <!--
+    <add key="baseAppAddress" value="@Microsoft.KeyVault(SecretName=mpnotify-prod-base-address)" />
+    <add key="client_id" value="@Microsoft.KeyVault(SecretName=mpnotify-prod-client-id)" />
+    <add key="clientSecret" value="@Microsoft.KeyVault(SecretName=mpnotify-prod-client-secret)" />
+    <add key="secret_id" value="@Microsoft.KeyVault(SecretName=mpnotify-prod-secret-id)" />
+    <add key="resource" value="@Microsoft.KeyVault(SecretName=mpnotify-prod-resource)" />
+    <add key="tenant_id" value="@Microsoft.KeyVault(SecretName=mpnotify-prod-tenant-id)" />
+    -->
+
+    <!-- EmailFromAddress - the authorized sender address as specified in SendGrid -->
+    <add key="EmailFromAddress" value="@Microsoft.KeyVault(SecretName=mpnotify-email-from-address)" />
+    <add key="EmailFromName" value="HaloMD IDR" />
+    <!-- The access key for SendGrid -->
+    <add key="SendGridApiKey" value="@Microsoft.KeyVault(SecretName=mpnotify-sendgrid-api-key)" />
+    <!-- Other settings -->
+    <add key="daysToKeepLogFiles" value="30" />
+  </appSettings>
 </configuration>


### PR DESCRIPTION
## Summary
- replace hard-coded credentials in Arbitration appsettings with Azure Key Vault secret references
- update MPNotify configuration to rely on Key Vault placeholders instead of embedded secrets

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c84eff647c832680e47e55ce444b46