### PR TITLE
Add arbitration app service module and wire environments

### DIFF
--- a/platform/infra/Azure/modules/app-service-arbitration/main.tf
+++ b/platform/infra/Azure/modules/app-service-arbitration/main.tf
@@ -1,0 +1,49 @@
+resource "azurerm_service_plan" "plan" {
+  name                = var.plan_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  os_type             = "Linux"
+  sku_name            = var.plan_sku
+  tags                = var.tags
+}
+
+resource "azurerm_linux_web_app" "app" {
+  name                = var.name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  service_plan_id     = azurerm_service_plan.plan.id
+  https_only          = true
+
+  identity { type = "SystemAssigned" }
+
+  site_config {
+    always_on = true
+    ftps_state = "Disabled"
+
+    application_stack {
+      dotnet_version = var.runtime_stack == "dotnet" ? var.runtime_version : null
+      node_version   = var.runtime_stack == "node"   ? var.runtime_version : null
+      python_version = var.runtime_stack == "python" ? var.runtime_version : null
+    }
+  }
+
+  app_settings = merge(
+    {
+      "APPINSIGHTS_CONNECTION_STRING" = var.app_insights_connection_string
+      "APPINSIGHTS_CONNECTIONSTRING"  = var.app_insights_connection_string
+    },
+    var.run_from_package ? { "WEBSITE_RUN_FROM_PACKAGE" = "1" } : {},
+    var.app_settings
+  )
+
+  dynamic "connection_string" {
+    for_each = var.connection_strings
+    content {
+      name  = connection_string.key
+      type  = connection_string.value.type
+      value = connection_string.value.value
+    }
+  }
+
+  tags = var.tags
+}

--- a/platform/infra/Azure/modules/app-service-arbitration/outputs.tf
+++ b/platform/infra/Azure/modules/app-service-arbitration/outputs.tf
@@ -1,0 +1,4 @@
+output "name"               { value = azurerm_linux_web_app.app.name }
+output "default_hostname"   { value = azurerm_linux_web_app.app.default_hostname }
+output "service_plan_id"    { value = azurerm_service_plan.plan.id }
+output "principal_id"       { value = azurerm_linux_web_app.app.identity[0].principal_id }

--- a/platform/infra/Azure/modules/app-service-arbitration/variables.tf
+++ b/platform/infra/Azure/modules/app-service-arbitration/variables.tf
@@ -1,0 +1,44 @@
+variable "name"                { type = string }
+variable "plan_name"           { type = string }
+variable "resource_group_name" { type = string }
+variable "location"            { type = string }
+
+variable "plan_sku" {
+  type    = string
+  default = "B1"
+}
+
+variable "runtime_stack" {
+  type    = string
+  default = "dotnet"
+}
+
+variable "runtime_version" {
+  type    = string
+  default = "8.0"
+}
+
+variable "app_insights_connection_string" { type = string }
+
+variable "connection_strings" {
+  type = map(object({
+    type  = string
+    value = string
+  }))
+  default = {}
+}
+
+variable "app_settings" {
+  type    = map(string)
+  default = {}
+}
+
+variable "run_from_package" {
+  type    = bool
+  default = true
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/platform/infra/envs/dev/main.tf
+++ b/platform/infra/envs/dev/main.tf
@@ -6,10 +6,12 @@ locals {
   aks_name          = "aks-${var.project_name}-${var.env_name}"
   kv_name           = "kv-${var.project_name}-${var.env_name}"
   log_name          = "log-${var.project_name}-${var.env_name}"
-  plan_name         = "asp-${var.project_name}-${var.env_name}"
-  func_cron_name    = "func-cron-${var.project_name}-${var.env_name}"
+  plan_name          = "asp-${var.project_name}-${var.env_name}"
+  func_cron_name     = "func-cron-${var.project_name}-${var.env_name}"
   func_external_name = "func-ext-${var.project_name}-${var.env_name}"
-  web_name          = "web-${var.project_name}-${var.env_name}"
+  web_name           = "web-${var.project_name}-${var.env_name}"
+  arbitration_plan_name = "asp-${var.project_name}-${var.env_name}-arb"
+  arbitration_app_name  = "web-${var.project_name}-${var.env_name}-arb"
   storage_data_name = lower(replace("st${var.project_name}${var.env_name}data", "-", ""))
   sql_server_name   = "sql-${var.project_name}-${var.env_name}"
   aad_app_display   = "aad-${var.project_name}-${var.env_name}"
@@ -115,6 +117,22 @@ module "web" {
   plan_sku                       = var.web_plan_sku
   dotnet_version                 = var.web_dotnet_version
   app_insights_connection_string = var.app_insights_connection_string
+  tags                           = var.tags
+}
+
+module "arbitration_app" {
+  source                         = "../../Azure/modules/app-service-arbitration"
+  name                           = local.arbitration_app_name
+  plan_name                      = local.arbitration_plan_name
+  resource_group_name            = module.rg.name
+  location                       = var.location
+  plan_sku                       = var.arbitration_plan_sku
+  runtime_stack                  = var.arbitration_runtime_stack
+  runtime_version                = var.arbitration_runtime_version
+  app_insights_connection_string = var.app_insights_connection_string
+  connection_strings             = var.arbitration_connection_strings
+  app_settings                   = var.arbitration_app_settings
+  run_from_package               = var.arbitration_run_from_package
   tags                           = var.tags
 }
 

--- a/platform/infra/envs/dev/terraform.tfvars
+++ b/platform/infra/envs/dev/terraform.tfvars
@@ -30,6 +30,24 @@ web_dotnet_version = "8.0"
 function_external_runtime = "dotnet"
 function_cron_runtime = "python"
 
+arbitration_plan_sku         = "B1"
+arbitration_runtime_stack    = "dotnet"
+arbitration_runtime_version  = "8.0"
+arbitration_connection_strings = {
+  ConnStr = {
+    type  = "SQLAzure"
+    value = "Server=tcp:dev-arbit-sql.database.windows.net,1433;Initial Catalog=dev-arbit-db;User ID=sqladmin;Password=P@ssw0rd123!;Encrypt=True;"
+  }
+  IDRConnStr = {
+    type  = "SQLAzure"
+    value = "Server=tcp:dev-idr-sql.database.windows.net,1433;Initial Catalog=dev-idr-db;User ID=sqladmin;Password=P@ssw0rd123!;Encrypt=True;"
+  }
+}
+arbitration_app_settings = {
+  "Storage__Connection" = "DefaultEndpointsProtocol=https;AccountName=devarbitstorage;AccountKey=FakeKeyForDev==;EndpointSuffix=core.windows.net"
+  "Storage__Container"  = "arbitration-calculator"
+}
+
 sql_db_name = "halomd"
 sql_sku_name = "GP_S_Gen5_2"
 sql_auto_pause_minutes = 60

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -112,6 +112,45 @@ variable "web_dotnet_version" {
   default     = "8.0"
 }
 
+variable "arbitration_plan_sku" {
+  type        = string
+  description = "App Service plan SKU for arbitration app"
+  default     = "B1"
+}
+
+variable "arbitration_runtime_stack" {
+  type        = string
+  description = "Runtime stack for the arbitration web app"
+  default     = "dotnet"
+}
+
+variable "arbitration_runtime_version" {
+  type        = string
+  description = "Runtime version for the arbitration web app"
+  default     = "8.0"
+}
+
+variable "arbitration_connection_strings" {
+  description = "Connection strings to configure on the arbitration app"
+  type = map(object({
+    type  = string
+    value = string
+  }))
+  default = {}
+}
+
+variable "arbitration_app_settings" {
+  description = "Additional app settings for the arbitration app"
+  type        = map(string)
+  default     = {}
+}
+
+variable "arbitration_run_from_package" {
+  description = "Whether the arbitration app should run from package"
+  type        = bool
+  default     = true
+}
+
 variable "function_external_runtime" {
   type        = string
   description = "Runtime for external function app"

--- a/platform/infra/envs/prod/main.tf
+++ b/platform/infra/envs/prod/main.tf
@@ -9,6 +9,8 @@ locals {
 
   web_plan  = "asp-halomdweb-${var.env_name}-${var.location}"
   web_name  = "app-halomdweb-${var.env_name}"
+  arbitration_plan = "asp-${var.project_name}-arb-${var.env_name}-${var.location}"
+  arbitration_name = "app-${var.project_name}-arb-${var.env_name}"
 
   func_external_plan = "asp-external-${var.env_name}-${var.location}"
   func_external_name = "func-external-${var.env_name}"
@@ -81,6 +83,22 @@ module "web" {
   tags                           = var.tags
 }
 
+module "arbitration_app" {
+  source                         = "../../Azure/modules/app-service-arbitration"
+  name                           = local.arbitration_name
+  plan_name                      = local.arbitration_plan
+  resource_group_name            = module.rg.name
+  location                       = var.location
+  plan_sku                       = var.arbitration_plan_sku
+  runtime_stack                  = var.arbitration_runtime_stack
+  runtime_version                = var.arbitration_runtime_version
+  app_insights_connection_string = module.logs.app_insights_connection_string
+  connection_strings             = var.arbitration_connection_strings
+  app_settings                   = var.arbitration_app_settings
+  run_from_package               = var.arbitration_run_from_package
+  tags                           = var.tags
+}
+
 module "func_external" {
   source                         = "../../Azure/modules/function-app"
   name                           = local.func_external_name
@@ -142,6 +160,7 @@ output "resource_group_name"        { value = module.rg.name }
 output "acr_name"                   { value = var.enable_acr ? module.acr[0].name : null }
 output "aks_name"                   { value = var.enable_aks ? module.aks[0].name : null }
 output "web_app_name"               { value = module.web.name }
+output "arbitration_app_name"       { value = module.arbitration_app.name }
 output "func_external_name"         { value = module.func_external.name }
 output "func_cron_name"             { value = module.func_cron.name }
 output "storage_data_account_name"  { value = var.enable_storage ? module.storage_data[0].name : null }

--- a/platform/infra/envs/prod/terraform.tfvars
+++ b/platform/infra/envs/prod/terraform.tfvars
@@ -26,6 +26,24 @@ web_dotnet_version        = "8.0"
 function_external_runtime = "dotnet"
 function_cron_runtime     = "python"
 
+arbitration_plan_sku         = "P1v3"
+arbitration_runtime_stack    = "dotnet"
+arbitration_runtime_version  = "8.0"
+arbitration_connection_strings = {
+  ConnStr = {
+    type  = "SQLAzure"
+    value = "Server=tcp:prod-arbit-sql.database.windows.net,1433;Initial Catalog=prod-arbit-db;User ID=sqladmin;Password=P@ssw0rd123!;Encrypt=True;"
+  }
+  IDRConnStr = {
+    type  = "SQLAzure"
+    value = "Server=tcp:prod-idr-sql.database.windows.net,1433;Initial Catalog=prod-idr-db;User ID=sqladmin;Password=P@ssw0rd123!;Encrypt=True;"
+  }
+}
+arbitration_app_settings = {
+  "Storage__Connection" = "DefaultEndpointsProtocol=https;AccountName=prodarbitstorage;AccountKey=FakeKeyForProd==;EndpointSuffix=core.windows.net"
+  "Storage__Container"  = "arbitration-calculator"
+}
+
 sql_db_name               = "halomd"
 sql_sku_name              = "GP_S_Gen5_2"
 sql_auto_pause_minutes    = 60

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -58,3 +58,42 @@ variable "sql_firewall_rules" {
     end_ip_address   = string
   }))
 }
+
+variable "arbitration_plan_sku" {
+  type        = string
+  description = "App Service plan SKU for the arbitration app"
+  default     = "P1v3"
+}
+
+variable "arbitration_runtime_stack" {
+  type        = string
+  description = "Runtime stack for the arbitration app"
+  default     = "dotnet"
+}
+
+variable "arbitration_runtime_version" {
+  type        = string
+  description = "Runtime version for the arbitration app"
+  default     = "8.0"
+}
+
+variable "arbitration_connection_strings" {
+  description = "Connection strings applied to the arbitration app"
+  type = map(object({
+    type  = string
+    value = string
+  }))
+  default = {}
+}
+
+variable "arbitration_app_settings" {
+  description = "Additional app settings for the arbitration app"
+  type        = map(string)
+  default     = {}
+}
+
+variable "arbitration_run_from_package" {
+  description = "Whether the arbitration app runs from package"
+  type        = bool
+  default     = true
+}

--- a/platform/infra/envs/stage/main.tf
+++ b/platform/infra/envs/stage/main.tf
@@ -9,6 +9,8 @@ locals {
 
   web_plan  = "asp-halomdweb-${var.env_name}-${var.location}"
   web_name  = "app-halomdweb-${var.env_name}"
+  arbitration_plan = "asp-${var.project_name}-arb-${var.env_name}-${var.location}"
+  arbitration_name = "app-${var.project_name}-arb-${var.env_name}"
 
   func_external_plan = "asp-external-${var.env_name}-${var.location}"
   func_external_name = "func-external-${var.env_name}"
@@ -81,6 +83,22 @@ module "web" {
   tags                           = var.tags
 }
 
+module "arbitration_app" {
+  source                         = "../../Azure/modules/app-service-arbitration"
+  name                           = local.arbitration_name
+  plan_name                      = local.arbitration_plan
+  resource_group_name            = module.rg.name
+  location                       = var.location
+  plan_sku                       = var.arbitration_plan_sku
+  runtime_stack                  = var.arbitration_runtime_stack
+  runtime_version                = var.arbitration_runtime_version
+  app_insights_connection_string = module.logs.app_insights_connection_string
+  connection_strings             = var.arbitration_connection_strings
+  app_settings                   = var.arbitration_app_settings
+  run_from_package               = var.arbitration_run_from_package
+  tags                           = var.tags
+}
+
 module "func_external" {
   source                         = "../../Azure/modules/function-app"
   name                           = local.func_external_name
@@ -142,6 +160,7 @@ output "resource_group_name"        { value = module.rg.name }
 output "acr_name"                   { value = var.enable_acr ? module.acr[0].name : null }
 output "aks_name"                   { value = var.enable_aks ? module.aks[0].name : null }
 output "web_app_name"               { value = module.web.name }
+output "arbitration_app_name"       { value = module.arbitration_app.name }
 output "func_external_name"         { value = module.func_external.name }
 output "func_cron_name"             { value = module.func_cron.name }
 output "storage_data_account_name"  { value = var.enable_storage ? module.storage_data[0].name : null }

--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -26,6 +26,24 @@ web_dotnet_version        = "8.0"
 function_external_runtime = "dotnet"
 function_cron_runtime     = "python"
 
+arbitration_plan_sku         = "P1v3"
+arbitration_runtime_stack    = "dotnet"
+arbitration_runtime_version  = "8.0"
+arbitration_connection_strings = {
+  ConnStr = {
+    type  = "SQLAzure"
+    value = "Server=tcp:stage-arbit-sql.database.windows.net,1433;Initial Catalog=stage-arbit-db;User ID=sqladmin;Password=P@ssw0rd123!;Encrypt=True;"
+  }
+  IDRConnStr = {
+    type  = "SQLAzure"
+    value = "Server=tcp:stage-idr-sql.database.windows.net,1433;Initial Catalog=stage-idr-db;User ID=sqladmin;Password=P@ssw0rd123!;Encrypt=True;"
+  }
+}
+arbitration_app_settings = {
+  "Storage__Connection" = "DefaultEndpointsProtocol=https;AccountName=stagearbitstorage;AccountKey=FakeKeyForStage==;EndpointSuffix=core.windows.net"
+  "Storage__Container"  = "arbitration-calculator"
+}
+
 sql_db_name               = "halomd"
 sql_sku_name              = "GP_S_Gen5_2"
 sql_auto_pause_minutes    = 60

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -58,3 +58,42 @@ variable "sql_firewall_rules" {
     end_ip_address   = string
   }))
 }
+
+variable "arbitration_plan_sku" {
+  type        = string
+  description = "App Service plan SKU for the arbitration app"
+  default     = "P1v3"
+}
+
+variable "arbitration_runtime_stack" {
+  type        = string
+  description = "Runtime stack for the arbitration app"
+  default     = "dotnet"
+}
+
+variable "arbitration_runtime_version" {
+  type        = string
+  description = "Runtime version for the arbitration app"
+  default     = "8.0"
+}
+
+variable "arbitration_connection_strings" {
+  description = "Connection strings applied to the arbitration app"
+  type = map(object({
+    type  = string
+    value = string
+  }))
+  default = {}
+}
+
+variable "arbitration_app_settings" {
+  description = "Additional app settings for the arbitration app"
+  type        = map(string)
+  default     = {}
+}
+
+variable "arbitration_run_from_package" {
+  description = "Whether the arbitration app runs from package"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Summary
- add an app-service-arbitration module that provisions the plan, linux web app, runtime stack configuration, and connection strings
- expose module inputs for runtime, plan sizing, app settings, and connection strings
- wire the dev, stage, and prod environments to use the new module with environment-specific configuration and outputs

## Testing
- `terraform fmt -recursive` *(fails: terraform command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c84f5316488326bbd98ce2864c0765