### PR TITLE
Add GitHub Actions workflow for Terraform deployments

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -1,0 +1,58 @@
+name: Terraform Deployments
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'platform/infra/**'
+      - '.github/workflows/terraform-deploy.yml'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target environment to deploy
+        type: choice
+        default: dev
+        options:
+          - dev
+          - stage
+          - prod
+
+env:
+  TF_VERSION: '1.7.5'
+  TF_IN_AUTOMATION: 'true'
+
+jobs:
+  terraform:
+    name: Terraform Deployment
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment || 'dev' }}
+    env:
+      TARGET_ENV: ${{ github.event.inputs.environment || 'dev' }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Prepare environment
+        id: env
+        run: |
+          echo "environment=${TARGET_ENV}" >> "$GITHUB_OUTPUT"
+          echo "TF_WORKING_DIR=platform/infra/envs/${TARGET_ENV}" >> "$GITHUB_ENV"
+          echo "AZURE_SECRET_NAME=AZURE_CREDENTIALS_${TARGET_ENV^^}" >> "$GITHUB_ENV"
+      - uses: actions/checkout@v4
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets[env.AZURE_SECRET_NAME] }}
+      - name: Terraform Init
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform init
+      - name: Terraform Plan
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform plan -out=tfplan
+      - name: Terraform Apply
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform apply -input=false -auto-approve tfplan


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that provisions Terraform for deployments on push and manual dispatch
- authenticate to Azure using service principal credentials and run init/plan/apply in the selected environment directory

## Testing
- not run (pipeline definition only)


------
https://chatgpt.com/codex/tasks/task_e_68c851e258dc832687970af47a781af2