### PR TITLE
Add link to Angular client documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains:
 - **Azure DevOps CI/CD** under `.ado/` (reusable templates consumed by the multi-stage pipeline).
 - **Bootstrap scripts** for Terraform state.
 - **Docs** for setup, naming, and migration.
+- **Angular client developers**: see [`Arbitration/MPArbitration/ClientApp/README.md`](Arbitration/MPArbitration/ClientApp/README.md) for project-specific guidance.
 
 > **Posture**: AKS/ACR are present as modules but **disabled by default**. Optional **Storage** and **SQL** modules exist and are **off by default**. Key Vault public access is **toggleable**.
 


### PR DESCRIPTION
## Summary
- add a root README pointer to the Angular client app documentation for front-end developers

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c857182200832693e54be3e34036b2