### PR TITLE
Replace placeholder citations with markdown references

### DIFF
--- a/README-ALL-IN-ONE.md
+++ b/README-ALL-IN-ONE.md
@@ -10,7 +10,7 @@ This document consolidates all guidance into **one file** you can hand to your t
 - Step‑by‑step **first run**
 - Best practices, troubleshooting, and key YAML snippets
 
-> **No secrets in the repository**: all credentials are read from **Azure Key Vault at runtime** via the ADO service connections. Apply uses the **saved plan artifact** only. fileciteturn0file9
+> **No secrets in the repository**: all credentials are read from **Azure Key Vault at runtime** via the ADO service connections. Apply uses the **saved plan artifact** only.【F:docs/SECRETS-AKV.md†L4-L80】
 
 ---
 
@@ -18,7 +18,7 @@ This document consolidates all guidance into **one file** you can hand to your t
 
 - **PR to `main`** → pipeline runs **Validate + Plan** for **dev, stage, prod**. **No applies** on PR runs.  
 - **Merge to `main`** → pipeline runs **Apply_Dev** automatically, then waits for **Environment approvals** to apply to **stage** and **prod**.  
-- Secrets are **never** in code; the pipeline reads them from **AKV** during **Plan**, and **Apply** uses the previously saved `.tfplan`. fileciteturn0file9
+- Secrets are **never** in code; the pipeline reads them from **AKV** during **Plan**, and **Apply** uses the previously saved `.tfplan`.【F:docs/SECRETS-AKV.md†L4-L80】
 
 ---
 
@@ -41,16 +41,16 @@ Create **three** Azure Resource Manager service connections using **Workload ide
 - `sc-azure-oidc-stage`
 - `sc-azure-oidc-prod`
 
-Grant each **Contributor** on the target scope and **Storage Blob Data Contributor** on the tfstate Storage Account. fileciteturn0file1
+Grant each **Contributor** on the target scope and **Storage Blob Data Contributor** on the tfstate Storage Account.【F:docs/ADO-setup.md†L4-L12】
 
 ### 3.2 Environments & approvals
 
 Create ADO **Environments**: `dev`, `stage`, `prod`.  
-Add **Approvals** for `stage` and `prod` (SRE/lead/change approvers). Optionally add **Branch control** to allow only `refs/heads/main`. fileciteturn0file1
+Add **Approvals** for `stage` and `prod` (SRE/lead/change approvers). Optionally add **Branch control** to allow only `refs/heads/main`.【F:docs/ADO-setup.md†L11-L15】
 
 ### 3.3 Branch policies
 
-Protect `main`: **require PR**, **build validation**, reviewers, and comment resolution. fileciteturn0file1
+Protect `main`: **require PR**, **build validation**, reviewers, and comment resolution.【F:docs/ADO-setup.md†L15-L16】
 
 ---
 
@@ -64,7 +64,7 @@ Create these as **Pipeline variables** or **Variable Groups**. They are **not** 
 - `TF_LOCK_TIMEOUT` = `20m`  
 - `USE_AKV_FOR_SECRETS` = `true` (pipeline pulls secrets from AKV during **Plan**)  
 - `AKV_SECRET_SQL_ADMIN_LOGIN_NAME` = `sql-admin-login`  
-- `AKV_SECRET_SQL_ADMIN_PASSWORD_NAME` = `sql-admin-password`  fileciteturn0file5
+- `AKV_SECRET_SQL_ADMIN_PASSWORD_NAME` = `sql-admin-password`【F:docs/GLOBAL-VARIABLES.md†L5-L10】
 
 ### 4.2 Per‑environment (non‑secret)
 
@@ -74,7 +74,7 @@ Create these as **Pipeline variables** or **Variable Groups**. They are **not** 
 
 - `AKV_ENABLE_DYNAMIC_IP_DEV` = `true`   *(Dev convenience for hosted agents)*  
 - `AKV_ENABLE_DYNAMIC_IP_STAGE` = `false`  
-- `AKV_ENABLE_DYNAMIC_IP_PROD` = `false`  *(Prefer private endpoint + self‑hosted agents)*  fileciteturn0file5
+- `AKV_ENABLE_DYNAMIC_IP_PROD` = `false`  *(Prefer private endpoint + self‑hosted agents)*【F:docs/GLOBAL-VARIABLES.md†L13-L19】【F:docs/SECRETS-AKV.md†L10-L21】
 
 ### 4.3 Optional (for Terraform‑managed RBAC on Key Vault)
 
@@ -82,7 +82,7 @@ Create these as **Pipeline variables** or **Variable Groups**. They are **not** 
 - `KV_CICD_PRINCIPAL_ID_STAGE` = `<objectId>`  
 - `KV_CICD_PRINCIPAL_ID_PROD` = `<objectId>`  
 
-If you set these, Terraform can grant **Key Vault Secrets User** to the pipeline identity (uncomment the role assignment block in `platform/infra/envs/<env>/main.tf`). fileciteturn0file5
+If you set these, Terraform can grant **Key Vault Secrets User** to the pipeline identity (uncomment the role assignment block in `platform/infra/envs/<env>/main.tf`).【F:docs/GLOBAL-VARIABLES.md†L21-L26】
 
 ---
 
@@ -90,7 +90,7 @@ If you set these, Terraform can grant **Key Vault Secrets User** to the pipeline
 
 ### 5.1 Goal
 
-- **No secrets** in repo/YAML. All credentials live in **AKV** and are retrieved at pipeline runtime via **OIDC**. fileciteturn0file8
+- **No secrets** in repo/YAML. All credentials live in **AKV** and are retrieved at pipeline runtime via **OIDC**.【F:docs/SECRETS-AKV.md†L3-L78】
 
 ### 5.2 Two network patterns
 
@@ -98,24 +98,24 @@ If you set these, Terraform can grant **Key Vault Secrets User** to the pipeline
 - Put AKV behind a **Private Endpoint** in your VNet.  
 - Run the pipeline on a **self‑hosted agent** inside that VNet.  
 - In AKV, set `public network access = false`.  
-- Result: no IP allow‑listing needed. fileciteturn0file8
+- Result: no IP allow‑listing needed.【F:docs/SECRETS-AKV.md†L10-L15】
 
 **Fallback — Public access with temporary IP allow‑listing**  
 - Keep `public_network_access_enabled = true`.  
 - Set AKV firewall `default_action = "Deny"`; allow selected networks only.  
-- The pipeline **detects the agent’s public IP**, **adds** it before secret reads, and **removes** it at the end (trap on exit). Works with Microsoft‑hosted agents. fileciteturn0file8
+- The pipeline **detects the agent’s public IP**, **adds** it before secret reads, and **removes** it at the end (trap on exit). Works with Microsoft‑hosted agents.【F:docs/SECRETS-AKV.md†L16-L21】【F:.ado/templates/tf-plan.yml†L65-L88】
 
 ### 5.3 Required RBAC
 
-Grant the service principal of your ADO service connection **Key Vault Secrets User** at the vault scope (data‑plane). Optional: **Key Vault Reader** for metadata. fileciteturn0file8
+Grant the service principal of your ADO service connection **Key Vault Secrets User** at the vault scope (data‑plane). Optional: **Key Vault Reader** for metadata.【F:docs/SECRETS-AKV.md†L25-L29】
 
 ### 5.4 Secret names in AKV
 
 Create per‑environment secrets (names configurable via variables):  
 - `sql-admin-login`  
-- `sql-admin-password` fileciteturn0file8
+- `sql-admin-password`【F:docs/SECRETS-AKV.md†L65-L67】
 
-> The pipeline passes them to Terraform via `-var "sql_admin_login=..." -var "sql_admin_password=..."` during **Plan**; **Apply** uses the saved plan and does not re‑read secrets. fileciteturn0file8
+> The pipeline passes them to Terraform via `-var "sql_admin_login=..." -var "sql_admin_password=..."` during **Plan**; **Apply** uses the saved plan and does not re‑read secrets.【F:docs/SECRETS-AKV.md†L71-L80】【F:.ado/templates/tf-plan.yml†L78-L94】
 
 ---
 
@@ -125,7 +125,7 @@ Create per‑environment secrets (names configurable via variables):
 - **feature/*** — short‑lived branches for features.  
 - **hotfix/*** — urgent fixes.  
 - **chore/*** — docs/tooling.  
-- *(Optional)* release tags for audit. fileciteturn0file4
+- *(Optional)* release tags for audit.【F:docs/DEV-Deploy-With-Branching.md†L5-L9】
 
 ```mermaid
 gitGraph
@@ -143,7 +143,7 @@ gitGraph
   checkout main
   merge hotfix/webapp-sku
 ```
-fileciteturn0file4
+*Diagram source.*【F:docs/DEV-Deploy-With-Branching.md†L11-L26】
 
 ---
 
@@ -195,7 +195,7 @@ flowchart LR
   AD --> SApprove --> AS --> StageRG
   AS --> PApprove --> AP --> ProdRG
 ```
-This is the merged overview of the PR and main pipeline runs. fileciteturn0file0
+This is the merged overview of the PR and main pipeline runs.【F:docs/README-CI-CD.md†L1-L6】
 
 ### 7.2 Developer‑centric (laptop) flow
 
@@ -223,7 +223,7 @@ flowchart TD
   end
   A1-->A2-->A3-->A4-->A5-->P1-->P2-->P3-->M1-->M2-->M3-->Z1
 ```
-Use this for onboarding and demos. fileciteturn0file3
+Use this for onboarding and demos.【F:docs/DEV-Deploy-From-Laptop.md†L1-L33】
 
 ---
 
@@ -233,16 +233,16 @@ Use this for onboarding and demos. fileciteturn0file3
 2) **Create ADO Environments**: `dev`, `stage`, `prod` (add approvals for stage/prod).  
 3) **Verify backends**: `platform/infra/envs/<env>/backend.tfvars` point to your tfstate and `use_azuread_auth = true`.  
 4) **Import pipeline**: point ADO to `azure-pipelines.yml`.  
-5) **Open a PR** to test **plans**; **merge** to apply **Dev**; **approve** to promote to **stage/prod**. fileciteturn0file6
+5) **Open a PR** to test **plans**; **merge** to apply **Dev**; **approve** to promote to **stage/prod**.【F:docs/step-by-step.md†L1-L7】
 
 ---
 
 ## 9) Developer: Deploy Dev from your laptop
 
 **Path A — Preferred:** *Laptop → PR → ADO auto‑applies Dev after merge* (keeps audit trail).  
-**Path B — One‑off:** *Direct local Terraform CLI to Dev* (for bootstrap/emergency). fileciteturn0file3
+**Path B — One‑off:** *Direct local Terraform CLI to Dev* (for bootstrap/emergency).【F:docs/DEV-Deploy-From-Laptop.md†L5-L46】
 
-- Path A Steps: clone → branch → change `platform/infra/envs/dev/terraform.tfvars` → push → PR → review **3 plans** → merge → Dev applies. fileciteturn0file3
+- Path A Steps: clone → branch → change `platform/infra/envs/dev/terraform.tfvars` → push → PR → review **3 plans** → merge → Dev applies.【F:docs/DEV-Deploy-From-Laptop.md†L5-L33】
 - Path B Commands (Linux/Mac):  
   ```bash
   cd platform/infra/envs/dev
@@ -250,7 +250,7 @@ Use this for onboarding and demos. fileciteturn0file3
   terraform plan -var-file=terraform.tfvars -out tfplan-dev.tfplan
   terraform apply tfplan-dev.tfplan
   ```
-  *(Use only when necessary; pipelines are preferred for audit and promotion.)* fileciteturn0file3
+  *(Use only when necessary; pipelines are preferred for audit and promotion.)*【F:docs/DEV-Deploy-From-Laptop.md†L35-L46】
 
 ---
 
@@ -269,7 +269,7 @@ condition: and(
 - Plan publishes `tfplan-<env>.tfplan`.  
 - Apply downloads and applies that **exact** plan file.
 
-**Why this matters:** it enforces change control and auditability. fileciteturn0file2
+**Why this matters:** it enforces change control and auditability.【F:docs/ci-cd-best-practices.md†L1-L5】
 
 ---
 
@@ -278,7 +278,7 @@ condition: and(
 - OIDC service connections (no client secrets).  
 - Apply the exact reviewed `.tfplan` artifact.  
 - Require PR + build validation to update `main`.  
-- Use ADO Environments for approvals on stage/prod. fileciteturn0file2
+- Use ADO Environments for approvals on stage/prod.【F:docs/ci-cd-best-practices.md†L1-L5】
 
 ---
 
@@ -287,7 +287,7 @@ condition: and(
 - Modularized Terraform under `platform/infra/Azure/modules`.  
 - Per‑env roots with independent state backends.  
 - GitOps flow: PR → plan; merge → apply Dev → gated stage/prod.  
-- Bash‑only pipelines (no marketplace dependency). fileciteturn0file7
+- Bash‑only pipelines (no marketplace dependency).【F:docs/what-changed-and-why.md†L1-L5】
 
 ---
 
@@ -307,7 +307,7 @@ condition: and(
 ## 14) Security options for AKV networking
 
 - **Stage/Prod**: prefer **Private Endpoint + self‑hosted agent**, set `kv_public_network_access = false`, keep `AKV_ENABLE_DYNAMIC_IP_* = false`.  
-- **Dev (hosted agents)**: set `kv_public_network_access = true`, AKV firewall `default_action = "Deny"`, and `AKV_ENABLE_DYNAMIC_IP_DEV = true` so the pipeline **temporarily** allow‑lists the agent’s IP, then **auto‑removes** it. fileciteturn0file8
+- **Dev (hosted agents)**: set `kv_public_network_access = true`, AKV firewall `default_action = "Deny"`, and `AKV_ENABLE_DYNAMIC_IP_DEV = true` so the pipeline **temporarily** allow‑lists the agent’s IP, then **auto‑removes** it.【F:docs/SECRETS-AKV.md†L16-L21】【F:.ado/templates/tf-plan.yml†L65-L88】
 
 ---
 
@@ -315,7 +315,7 @@ condition: and(
 
 **Global**: `TF_VERSION`, `TF_LOCK_TIMEOUT`, `USE_AKV_FOR_SECRETS`, `AKV_SECRET_SQL_ADMIN_LOGIN_NAME`, `AKV_SECRET_SQL_ADMIN_PASSWORD_NAME`  
 **Per‑env**: `KV_NAME_DEV|STAGE|PROD`, `AKV_ENABLE_DYNAMIC_IP_DEV|STAGE|PROD`  
-**Optional**: `KV_CICD_PRINCIPAL_ID_DEV|STAGE|PROD` (for TF‑managed Key Vault RBAC) fileciteturn0file5
+**Optional**: `KV_CICD_PRINCIPAL_ID_DEV|STAGE|PROD` (for TF‑managed Key Vault RBAC)【F:docs/GLOBAL-VARIABLES.md†L21-L24】
 
 ---
 


### PR DESCRIPTION
## Summary
- replace placeholder `filecite...` markers in `README-ALL-IN-ONE.md` with standard Markdown citations that point to the supporting docs and pipeline templates
- ensure each cited statement references the relevant guidance for secrets handling, Azure DevOps setup, branching, workflows, and AKV networking

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68c8571362248326ad01e17a91417af9