### PR TITLE
feat: add sql serverless module

### DIFF
--- a/platform/infra/Azure/modules/sql-serverless/main.tf
+++ b/platform/infra/Azure/modules/sql-serverless/main.tf
@@ -1,0 +1,31 @@
+resource "azurerm_mssql_server" "this" {
+  name                          = var.server_name
+  resource_group_name           = var.resource_group_name
+  location                      = var.location
+  version                       = "12.0"
+  administrator_login           = var.admin_login
+  administrator_login_password  = var.admin_password
+  minimum_tls_version           = var.minimum_tls_version
+  public_network_access_enabled = var.public_network_access_enabled
+  tags                          = var.tags
+}
+
+resource "azurerm_mssql_database" "this" {
+  name                        = var.db_name
+  server_id                   = azurerm_mssql_server.this.id
+  sku_name                    = var.sku_name
+  max_size_gb                 = var.max_size_gb
+  min_capacity                = var.min_capacity
+  auto_pause_delay_in_minutes = var.auto_pause_delay_in_minutes
+  zone_redundant              = var.zone_redundant
+  backup_storage_redundancy   = var.backup_storage_redundancy
+  tags                        = var.tags
+}
+
+resource "azurerm_mssql_firewall_rule" "this" {
+  for_each         = { for rule in var.firewall_rules : rule.name => rule }
+  name             = each.value.name
+  server_id        = azurerm_mssql_server.this.id
+  start_ip_address = each.value.start_ip_address
+  end_ip_address   = each.value.end_ip_address
+}

--- a/platform/infra/Azure/modules/sql-serverless/outputs.tf
+++ b/platform/infra/Azure/modules/sql-serverless/outputs.tf
@@ -1,0 +1,11 @@
+output "server_name" {
+  value = azurerm_mssql_server.this.name
+}
+
+output "server_fqdn" {
+  value = azurerm_mssql_server.this.fully_qualified_domain_name
+}
+
+output "database_id" {
+  value = azurerm_mssql_database.this.id
+}

--- a/platform/infra/Azure/modules/sql-serverless/variables.tf
+++ b/platform/infra/Azure/modules/sql-serverless/variables.tf
@@ -1,0 +1,81 @@
+variable "server_name" {
+  type = string
+}
+
+variable "db_name" {
+  type    = string
+  default = "halomd"
+}
+
+variable "resource_group_name" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "admin_login" {
+  type    = string
+  default = ""
+}
+
+variable "admin_password" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "public_network_access_enabled" {
+  type    = bool
+  default = true
+}
+
+variable "minimum_tls_version" {
+  type    = string
+  default = "1.2"
+}
+
+variable "sku_name" {
+  type    = string
+  default = "GP_S_Gen5_2"
+}
+
+variable "min_capacity" {
+  type    = number
+  default = 0.5
+}
+
+variable "auto_pause_delay_in_minutes" {
+  type    = number
+  default = 60
+}
+
+variable "max_size_gb" {
+  type    = number
+  default = 75
+}
+
+variable "zone_redundant" {
+  type    = bool
+  default = false
+}
+
+variable "backup_storage_redundancy" {
+  type    = string
+  default = "Local"
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "firewall_rules" {
+  type = list(object({
+    name             = string
+    start_ip_address = string
+    end_ip_address   = string
+  }))
+  default = []
+}

--- a/platform/infra/envs/dev/main.tf
+++ b/platform/infra/envs/dev/main.tf
@@ -58,7 +58,7 @@ module "aks" {
 
 module "sql" {
   count                         = var.enable_sql ? 1 : 0
-  source                        = "../../Azure/modules/sql-database"
+  source                        = "../../Azure/modules/sql-serverless"
   server_name                   = local.sql_server_name
   db_name                       = var.sql_db_name
   resource_group_name           = module.rg.name
@@ -170,4 +170,8 @@ output "app_insights_instrumentation_key" {
 
 output "log_analytics_workspace_id" {
   value = module.app_insights.log_analytics_workspace_id
+}
+
+output "sql_server_fqdn" {
+  value = var.enable_sql ? module.sql[0].server_fqdn : null
 }

--- a/platform/infra/envs/dev/terraform.tfvars
+++ b/platform/infra/envs/dev/terraform.tfvars
@@ -74,7 +74,7 @@ arbitration_app_settings = {
 sql_db_name = "halomd"
 sql_sku_name = "GP_S_Gen5_2"
 sql_auto_pause_minutes = 60
-sql_max_size_gb = 32
+sql_max_size_gb = 75
 sql_public_network_access = true
 sql_firewall_rules = [
   {

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -204,7 +204,7 @@ variable "sql_auto_pause_minutes" {
 variable "sql_max_size_gb" {
   type        = number
   description = "Maximum size of the SQL database in GB"
-  default     = 32
+  default     = 75
 }
 
 variable "sql_public_network_access" {

--- a/platform/infra/envs/prod/main.tf
+++ b/platform/infra/envs/prod/main.tf
@@ -146,7 +146,7 @@ module "storage_data" {
 
 module "sql" {
   count                            = var.enable_sql ? 1 : 0
-  source                           = "../../Azure/modules/sql-database"
+  source                           = "../../Azure/modules/sql-serverless"
   server_name                      = local.sql_server_name
   db_name                          = var.sql_db_name
   resource_group_name              = module.rg.name
@@ -178,6 +178,7 @@ output "func_cron_name"             { value = module.func_cron.name }
 output "storage_data_account_name"  { value = var.enable_storage ? module.storage_data[0].name : null }
 output "sql_server_name"            { value = var.enable_sql ? module.sql[0].server_name : null }
 output "sql_database_id"            { value = var.enable_sql ? module.sql[0].database_id : null }
+output "sql_server_fqdn"            { value = var.enable_sql ? module.sql[0].server_fqdn : null }
 output "aad_app_client_id"          { value = var.enable_aad_app ? module.aad_app[0].client_id : null }
 output "app_insights_connection_string"        { value = module.app_insights.application_insights_connection_string }
 output "app_insights_instrumentation_key"      { value = module.app_insights.application_insights_instrumentation_key }

--- a/platform/infra/envs/prod/terraform.tfvars
+++ b/platform/infra/envs/prod/terraform.tfvars
@@ -71,7 +71,7 @@ arbitration_app_settings = {
 sql_db_name               = "halomd"
 sql_sku_name              = "GP_S_Gen5_2"
 sql_auto_pause_minutes    = 60
-sql_max_size_gb           = 32
+sql_max_size_gb           = 75
 sql_public_network_access = true
 sql_firewall_rules = [
   {

--- a/platform/infra/envs/stage/main.tf
+++ b/platform/infra/envs/stage/main.tf
@@ -146,7 +146,7 @@ module "storage_data" {
 
 module "sql" {
   count                            = var.enable_sql ? 1 : 0
-  source                           = "../../Azure/modules/sql-database"
+  source                           = "../../Azure/modules/sql-serverless"
   server_name                      = local.sql_server_name
   db_name                          = var.sql_db_name
   resource_group_name              = module.rg.name
@@ -178,6 +178,7 @@ output "func_cron_name"             { value = module.func_cron.name }
 output "storage_data_account_name"  { value = var.enable_storage ? module.storage_data[0].name : null }
 output "sql_server_name"            { value = var.enable_sql ? module.sql[0].server_name : null }
 output "sql_database_id"            { value = var.enable_sql ? module.sql[0].database_id : null }
+output "sql_server_fqdn"            { value = var.enable_sql ? module.sql[0].server_fqdn : null }
 output "aad_app_client_id"          { value = var.enable_aad_app ? module.aad_app[0].client_id : null }
 output "app_insights_connection_string"        { value = module.app_insights.application_insights_connection_string }
 output "app_insights_instrumentation_key"      { value = module.app_insights.application_insights_instrumentation_key }

--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -71,7 +71,7 @@ arbitration_app_settings = {
 sql_db_name               = "halomd"
 sql_sku_name              = "GP_S_Gen5_2"
 sql_auto_pause_minutes    = 60
-sql_max_size_gb           = 32
+sql_max_size_gb           = 75
 sql_public_network_access = true
 sql_firewall_rules = [
   {


### PR DESCRIPTION
## Summary
- add an Azure SQL serverless module with standard configuration defaults and firewall support
- update environment stacks to consume the module, standardize the max size to 75 GB, and output the SQL server FQDN

## Testing
- terraform fmt -recursive *(fails: terraform not installed in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c85e2fb49083269d8d1c3cd464fcac