### PR TITLE
Sanitize dev tfvars and shift secrets to Key Vault

### DIFF
--- a/docs/SECRETS-AKV.md
+++ b/docs/SECRETS-AKV.md
@@ -65,8 +65,14 @@ Use these to create `azurerm_role_assignment` for **Key Vault Secrets User** at 
 Create these secrets **in each environment’s Key Vault** (names configurable via variables):
 - `sql-admin-login`
 - `sql-admin-password`
+- `app-service-primary-database-connection`
+- `arbitration-primary-connection`
+- `arbitration-idr-connection`
+- `arbitration-storage-connection`
 
 You can add more (e.g., `webapp-client-secret`) and extend the YAML similarly.
+
+> App Service / Function apps must have managed identities with **Key Vault Secrets User** access so the runtime can resolve `@Microsoft.KeyVault(...)` references configured in Terraform.
 
 ## How the pipeline uses AKV
 

--- a/platform/infra/envs/dev/main.tf
+++ b/platform/infra/envs/dev/main.tf
@@ -68,7 +68,7 @@ module "app_gateway" {
 }
 
 module "sql" {
-  count                         = var.enable_sql ? 1 : 0
+  count = var.enable_sql && var.sql_admin_login != "" && var.sql_admin_password != "" ? 1 : 0
   source                        = "../../Azure/modules/sql-serverless"
   server_name                   = local.sql_server_name
   database_name                 = var.sql_database_name

--- a/platform/infra/envs/dev/providers.tf
+++ b/platform/infra/envs/dev/providers.tf
@@ -11,6 +11,6 @@ terraform {
 provider "azurerm" {
   features {}
 
-  subscription_id = var.subscription_id
-  tenant_id       = var.tenant_id
+  subscription_id = var.subscription_id != "" ? var.subscription_id : null
+  tenant_id       = var.tenant_id != "" ? var.tenant_id : null
 }

--- a/platform/infra/envs/dev/terraform.tfvars
+++ b/platform/infra/envs/dev/terraform.tfvars
@@ -1,8 +1,10 @@
-project_name    = "arbit"
-env_name        = "dev"
-location        = "eastus"
-subscription_id = "930755b1-ef22-4721-a31a-1b6fbecf7da6"
-tenant_id       = "70750cc4-6f21-4c27-bb0e-8b7e66bcb2dd"
+project_name = "arbit"
+env_name     = "dev"
+location     = "eastus"
+
+# Secrets are injected at runtime via the pipeline / Key Vault.
+subscription_id = ""
+tenant_id       = ""
 
 tags = {
   project = "arbit"
@@ -23,7 +25,8 @@ subnets = {
   }
 }
 
-app_gateway_subnet_id = "/subscriptions/930755b1-ef22-4721-a31a-1b6fbecf7da6/resourceGroups/rg-arbit-dev/providers/Microsoft.Network/virtualNetworks/vnet-arbit-dev/subnets/appgw"
+# Reference subnets by key (no hard-coded IDs)
+app_gateway_subnet_key = "gateway"
 
 app_gateway_fqdn_prefix = "agw-arbit-dev"
 app_gateway_backend_fqdns = []
@@ -62,7 +65,7 @@ app_service_app_settings = {
 app_service_connection_strings = {
   PrimaryDatabase = {
     type  = "SQLAzure"
-    value = "Server=tcp:sql-arbit-dev.database.windows.net,1433;Initial Catalog=halomd;User ID=sqladmin;Password=P@ssw0rd1234!;Encrypt=True;"
+    value = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-dev.vault.azure.net/secrets/app-service-primary-database-connection)"
   }
 }
 
@@ -97,15 +100,15 @@ arbitration_runtime_version = "8.0"
 arbitration_connection_strings = {
   ConnStr = {
     type  = "SQLAzure"
-    value = "Server=tcp:dev-arbit-sql.database.windows.net,1433;Initial Catalog=dev-arbit-db;User ID=sqladmin;Password=P@ssw0rd123!;Encrypt=True;"
+    value = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-dev.vault.azure.net/secrets/arbitration-primary-connection)"
   }
   IDRConnStr = {
     type  = "SQLAzure"
-    value = "Server=tcp:dev-idr-sql.database.windows.net,1433;Initial Catalog=dev-idr-db;User ID=sqladmin;Password=P@ssw0rd123!;Encrypt=True;"
+    value = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-dev.vault.azure.net/secrets/arbitration-idr-connection)"
   }
 }
 arbitration_app_settings = {
-  "Storage__Connection" = "DefaultEndpointsProtocol=https;AccountName=devarbitstorage;AccountKey=FakeKeyForDev==;EndpointSuffix=core.windows.net"
+  "Storage__Connection" = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-dev.vault.azure.net/secrets/arbitration-storage-connection)"
   "Storage__Container"  = "arbitration-calculator"
 }
 
@@ -121,8 +124,8 @@ sql_max_size_gb          = 75
 sql_min_capacity         = 0.5
 sql_max_capacity         = 4
 sql_public_network_access = true
-sql_admin_login          = "sqladmin"
-sql_admin_password       = "P@ssw0rd1234!"
+sql_admin_login          = ""
+sql_admin_password       = ""
 
 sql_firewall_rules = [
   {

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -16,11 +16,13 @@ variable "project_name" {
 variable "subscription_id" {
   description = "Azure subscription ID."
   type        = string
+  default     = ""
 }
 
 variable "tenant_id" {
   description = "Azure tenant ID."
   type        = string
+  default     = ""
 }
 
 variable "tags" {
@@ -66,6 +68,7 @@ variable "app_gateway_subnet_key" {
 variable "app_gateway_subnet_id" {
   description = "Subnet resource ID for the Application Gateway."
   type        = string
+  default     = ""
 }
 
 # -------------------------
@@ -301,10 +304,12 @@ variable "sql_firewall_rules" {
 variable "sql_admin_login" {
   description = "Administrator login for the SQL server."
   type        = string
+  default     = ""
 }
 
 variable "sql_admin_password" {
   description = "Administrator password for the SQL server."
   type        = string
   sensitive   = true
+  default     = ""
 }


### PR DESCRIPTION
## Summary
- remove committed secrets from the dev tfvars, replace connection strings with Key Vault references, and switch to using the subnet key
- make subscription/tenant and SQL admin values optional so the pipeline or Key Vault can provide them securely and gate SQL creation on secret availability
- document the additional Key Vault secret names required for the new references

## Testing
- not run (terraform CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c87b2cd9448326aa579c93a5972c72