### PR TITLE
Align dev SQL auto pause variable usage

### DIFF
--- a/docs/network/Resource per Env for the Arbit project.txt
+++ b/docs/network/Resource per Env for the Arbit project.txt
@@ -40,7 +40,7 @@ function_cron_runtime     = "python"
 
 sql_db_name               = "halomd"
 sql_sku_name              = "GP_S_Gen5_2"
-sql_auto_pause_minutes    = 60
+sql_auto_pause_delay      = 60
 sql_max_size_gb           = 32
 sql_public_network_access = true
 # sql_admin_login    = ""
@@ -88,7 +88,7 @@ function_cron_runtime     = "python"
 
 sql_db_name               = "halomd"
 sql_sku_name              = "GP_S_Gen5_2"
-sql_auto_pause_minutes    = 60
+sql_auto_pause_delay      = 60
 sql_max_size_gb           = 32
 sql_public_network_access = true
 # sql_admin_login    = ""
@@ -132,7 +132,7 @@ function_cron_runtime     = "python"
 
 sql_db_name               = "halomd"
 sql_sku_name              = "GP_S_Gen5_2"
-sql_auto_pause_minutes    = 60
+sql_auto_pause_delay      = 60
 sql_max_size_gb           = 32
 sql_public_network_access = true
 # sql_admin_login    = ""

--- a/platform/infra/envs/dev/main.tf
+++ b/platform/infra/envs/dev/main.tf
@@ -78,7 +78,7 @@ module "sql" {
   administrator_password        = var.sql_admin_password
   public_network_access_enabled = var.sql_public_network_access
   sku_name                      = var.sql_sku_name
-  auto_pause_delay_in_minutes   = var.sql_auto_pause_minutes
+  auto_pause_delay_in_minutes   = var.sql_auto_pause_delay
   max_size_gb                   = var.sql_max_size_gb
   min_capacity                  = var.sql_min_capacity
   max_capacity                  = var.sql_max_capacity

--- a/platform/infra/envs/dev/terraform.tfvars
+++ b/platform/infra/envs/dev/terraform.tfvars
@@ -115,7 +115,6 @@ arbitration_app_settings = {
 sql_database_name        = "halomd"
 sql_db_name              = "halomd"
 sql_sku_name             = "GP_S_Gen5_2"
-sql_auto_pause_minutes   = 60
 sql_auto_pause_delay     = 60
 sql_max_size_gb          = 75
 sql_min_capacity         = 0.5

--- a/platform/infra/envs/prod/terraform.tfvars
+++ b/platform/infra/envs/prod/terraform.tfvars
@@ -89,7 +89,6 @@ sql_db_name              = "halomd"
 sql_sku_name             = "GP_S_Gen5_4"
 sql_max_size_gb          = 128
 sql_auto_pause_delay     = 60
-sql_auto_pause_minutes   = 60
 sql_min_capacity         = 2
 sql_max_capacity         = 8
 sql_public_network_access = true

--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -89,7 +89,6 @@ sql_db_name              = "halomd"
 sql_sku_name             = "GP_S_Gen5_2"
 sql_max_size_gb          = 64
 sql_auto_pause_delay     = 60
-sql_auto_pause_minutes   = 60
 sql_min_capacity         = 1
 sql_max_capacity         = 6
 sql_public_network_access = true


### PR DESCRIPTION
## Summary
- update the dev SQL module to read the sql_auto_pause_delay variable
- remove the legacy sql_auto_pause_minutes overrides from environment tfvars
- refresh documentation references to the renamed auto pause variable

## Testing
- not run (terraform not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c87b2dec48832683d21641f8ecfd63