### PR TITLE
Update backend tfvars for stage and prod

### DIFF
--- a/platform/infra/envs/prod/backend.tfvars
+++ b/platform/infra/envs/prod/backend.tfvars
@@ -2,7 +2,7 @@
 resource_group_name  = "prod-eus2-ops-rg-1"
 storage_account_name = "prodeus2terraform"
 container_name       = "arbit"
-key                  = "arbit/prod.tfstate"
+key                  = "halomd-prod-tfstate-kv"
 use_azuread_auth     = true
-subscription_id = "930755b1-ef22-4721-a31a-1b6fbecf7da6"
+subscription_id = "40f3e169-b544-4789-936a-5526146e3b8e"
 tenant_id       = "70750cc4-6f21-4c27-bb0e-8b7e66bcb2dd"

--- a/platform/infra/envs/stage/backend.tfvars
+++ b/platform/infra/envs/stage/backend.tfvars
@@ -1,8 +1,8 @@
 
 resource_group_name  = "staging-eus2-ops-rg-1"
-storage_account_name = "deveus2terraform"
+storage_account_name = "stageeus2terraform"
 container_name       = "arbit"
-key                  = "arbit/stage.tfstate"
+key                  = "halomd-stage-tfstate-kv"
 use_azuread_auth     = true
-subscription_id = "930755b1-ef22-4721-a31a-1b6fbecf7da6"
+subscription_id = "6f6a108b-c1fa-4d44-adb9-60e5de23f405"
 tenant_id       = "70750cc4-6f21-4c27-bb0e-8b7e66bcb2dd"


### PR DESCRIPTION
## Summary
- update the stage backend configuration to point to the stage storage account, key, and subscription
- update the prod backend configuration to point to the new key and subscription

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68c881e44eb48326957c9954fac32015