### PR TITLE
Configure pipeline variable groups

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,12 @@
 # Multi-stage ADO pipeline (PR -> Validate & Plan; merge -> Apply dev -> gated stage/prod)
 # Includes AKV-driven secrets and optional temporary IP allow-listing for hosted agents.
 
+variables:
+  - group: terraform-global-common
+  - group: terraform-dev        # for Validate & Plan dev
+  - group: terraform-stage      # used during Plan_All and Apply_Stage
+  - group: terraform-prod       # used during Plan_All and Apply_Prod
+
 trigger:
   branches: { include: [ main ] }
   paths: { include: [ 'platform/infra/**', '.ado/**' ] }
@@ -10,10 +16,6 @@ pr:
   paths: { include: [ 'platform/infra/**', '.ado/**' ] }
 
 pool: { vmImage: 'ubuntu-latest' }
-
-variables:
-  TF_VERSION: '1.7.5'
-  TF_LOCK_TIMEOUT: '20m'
 
 stages:
 - stage: Validate


### PR DESCRIPTION
## Summary
- load the terraform variable groups for common, dev, stage, and prod at the top of the pipeline
- rely on the shared TF_VERSION and TF_LOCK_TIMEOUT values from the variable group instead of inline definitions

## Testing
- not run (pipeline configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68c881e95d888326b7fe531aedb794c6