### PR TITLE
Read Azure IDs from pipeline variables

### DIFF
--- a/.ado/templates/tf-apply.yml
+++ b/.ado/templates/tf-apply.yml
@@ -9,11 +9,17 @@ parameters:
   - name: lockTimeout
     type: string
     default: '20m'
+  - name: variableGroup
+    type: string
+    default: ''
 
 jobs:
 - deployment: apply_${{ parameters.envName }}
   displayName: "Apply (${{ parameters.envName }})"
   environment: ${{ parameters.envName }}
+  ${{ if ne(parameters.variableGroup, '') }}:
+    variables:
+      - group: ${{ parameters.variableGroup }}
   strategy:
     runOnce:
       deploy:

--- a/.ado/templates/tf-plan.yml
+++ b/.ado/templates/tf-plan.yml
@@ -14,6 +14,9 @@ parameters:
   - name: extraVarFlags
     type: string
     default: ''
+  - name: variableGroup
+    type: string
+    default: ''
   # AKV integration
   - name: useAkv
     type: string
@@ -34,6 +37,9 @@ parameters:
 jobs:
 - job: plan_${{ parameters.envName }}
   displayName: "Plan (${{ parameters.envName }})"
+  ${{ if ne(parameters.variableGroup, '') }}:
+    variables:
+      - group: ${{ parameters.variableGroup }}
   steps:
   - checkout: self
   - task: AzureCLI@2
@@ -61,6 +67,7 @@ jobs:
         SECRET_LOGIN='${{ parameters.akvSecretSqlAdminLoginName }}'
         SECRET_PASS='${{ parameters.akvSecretSqlAdminPasswordName }}'
         AKV_VAR_FLAGS=""
+        SUB_TENANT_VAR_FLAGS=""
 
         if [[ "$USE_AKV" == "true" && -n "$KV_NAME" ]]; then
           if [[ "$DYN_IP" == "true" ]]; then
@@ -89,8 +96,15 @@ jobs:
         fi
 
         cd platform/infra/envs/${{ parameters.envName }}
+        if [[ -n "${AZ_SUBSCRIPTION_ID:-}" ]]; then
+          SUB_TENANT_VAR_FLAGS="${SUB_TENANT_VAR_FLAGS} -var \"subscription_id=${AZ_SUBSCRIPTION_ID}\""
+        fi
+        if [[ -n "${AZ_TENANT_ID:-}" ]]; then
+          SUB_TENANT_VAR_FLAGS="${SUB_TENANT_VAR_FLAGS} -var \"tenant_id=${AZ_TENANT_ID}\""
+        fi
+
         terraform init -reconfigure -backend-config=backend.tfvars -lock-timeout='${{ parameters.lockTimeout }}'
-        terraform plan -input=false -var-file=terraform.tfvars ${{ parameters.extraVarFlags }} ${AKV_VAR_FLAGS} -out "$BUILD_SOURCESDIRECTORY/tfplan-${{ parameters.envName }}.tfplan"
+        terraform plan -input=false -var-file=terraform.tfvars ${{ parameters.extraVarFlags }} ${SUB_TENANT_VAR_FLAGS} ${AKV_VAR_FLAGS} -out "$BUILD_SOURCESDIRECTORY/tfplan-${{ parameters.envName }}.tfplan"
   - task: PublishPipelineArtifact@1
     inputs:
       targetPath: '$(Build.SourcesDirectory)/tfplan-${{ parameters.envName }}.tfplan'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,7 @@ stages:
       serviceConnection: sc-azure-oidc-dev
       tfVersion: ${{ variables.TF_VERSION }}
       lockTimeout: ${{ variables.TF_LOCK_TIMEOUT }}
+      variableGroup: terraform-dev
       # Pass the CI/CD principal Object ID if provided (used to grant KV Secrets User via TF)
       extraVarFlags: '-var "kv_cicd_principal_id=$(KV_CICD_PRINCIPAL_ID_DEV)"'
       # AKV integration (pull SQL secrets at plan time)
@@ -48,6 +49,7 @@ stages:
       serviceConnection: sc-azure-oidc-stage
       tfVersion: ${{ variables.TF_VERSION }}
       lockTimeout: ${{ variables.TF_LOCK_TIMEOUT }}
+      variableGroup: terraform-stage
       extraVarFlags: '-var "kv_cicd_principal_id=$(KV_CICD_PRINCIPAL_ID_STAGE)"'
       useAkv: '$(USE_AKV_FOR_SECRETS)'
       akvName: '$(KV_NAME_STAGE)'
@@ -60,6 +62,7 @@ stages:
       serviceConnection: sc-azure-oidc-prod
       tfVersion: ${{ variables.TF_VERSION }}
       lockTimeout: ${{ variables.TF_LOCK_TIMEOUT }}
+      variableGroup: terraform-prod
       extraVarFlags: '-var "kv_cicd_principal_id=$(KV_CICD_PRINCIPAL_ID_PROD)"'
       useAkv: '$(USE_AKV_FOR_SECRETS)'
       akvName: '$(KV_NAME_PROD)'
@@ -78,6 +81,7 @@ stages:
       serviceConnection: sc-azure-oidc-dev
       tfVersion: ${{ variables.TF_VERSION }}
       lockTimeout: ${{ variables.TF_LOCK_TIMEOUT }}
+      variableGroup: terraform-dev
 
 - stage: Apply_Stage
   displayName: Terraform Apply (stage)
@@ -90,6 +94,7 @@ stages:
       serviceConnection: sc-azure-oidc-stage
       tfVersion: ${{ variables.TF_VERSION }}
       lockTimeout: ${{ variables.TF_LOCK_TIMEOUT }}
+      variableGroup: terraform-stage
 
 - stage: Apply_Prod
   displayName: Terraform Apply (prod)
@@ -102,3 +107,4 @@ stages:
       serviceConnection: sc-azure-oidc-prod
       tfVersion: ${{ variables.TF_VERSION }}
       lockTimeout: ${{ variables.TF_LOCK_TIMEOUT }}
+      variableGroup: terraform-prod

--- a/docs/GLOBAL-VARIABLES.md
+++ b/docs/GLOBAL-VARIABLES.md
@@ -14,6 +14,9 @@
 - `KV_NAME_STAGE` = `kv-arbit-stage`
 - `KV_NAME_PROD` = `kv-arbit-prod`
 
+- `AZ_SUBSCRIPTION_ID` = `<subscription guid>`
+- `AZ_TENANT_ID` = `<tenant guid>`
+
 - `AKV_ENABLE_DYNAMIC_IP_DEV` = `true`   # temp IP allow during plan on hosted agents
 - `AKV_ENABLE_DYNAMIC_IP_STAGE` = `false`
 - `AKV_ENABLE_DYNAMIC_IP_PROD` = `false`

--- a/platform/infra/envs/dev/providers.tf
+++ b/platform/infra/envs/dev/providers.tf
@@ -8,9 +8,14 @@ terraform {
   }
 }
 
+locals {
+  provider_subscription_id = try(trimspace(var.subscription_id), "") != "" ? var.subscription_id : null
+  provider_tenant_id       = try(trimspace(var.tenant_id), "") != "" ? var.tenant_id : null
+}
+
 provider "azurerm" {
   features {}
 
-  subscription_id = var.subscription_id != "" ? var.subscription_id : null
-  tenant_id       = var.tenant_id != "" ? var.tenant_id : null
+  subscription_id = local.provider_subscription_id
+  tenant_id       = local.provider_tenant_id
 }

--- a/platform/infra/envs/dev/terraform.tfvars
+++ b/platform/infra/envs/dev/terraform.tfvars
@@ -3,8 +3,6 @@ env_name     = "dev"
 location     = "eastus"
 
 # Secrets are injected at runtime via the pipeline / Key Vault.
-subscription_id = ""
-tenant_id       = ""
 
 tags = {
   project = "arbit"

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -16,13 +16,13 @@ variable "project_name" {
 variable "subscription_id" {
   description = "Azure subscription ID."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "tenant_id" {
   description = "Azure tenant ID."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "tags" {

--- a/platform/infra/envs/prod/providers.tf
+++ b/platform/infra/envs/prod/providers.tf
@@ -7,9 +7,14 @@ terraform {
   }
 }
 
+locals {
+  provider_subscription_id = try(trimspace(var.subscription_id), "") != "" ? var.subscription_id : null
+  provider_tenant_id       = try(trimspace(var.tenant_id), "") != "" ? var.tenant_id : null
+}
+
 provider "azurerm" {
   features {}
 
-  subscription_id = var.subscription_id
-  tenant_id       = var.tenant_id
+  subscription_id = local.provider_subscription_id
+  tenant_id       = local.provider_tenant_id
 }

--- a/platform/infra/envs/prod/terraform.tfvars
+++ b/platform/infra/envs/prod/terraform.tfvars
@@ -1,8 +1,6 @@
-project_name    = "arbit"
-env_name        = "prod"
-location        = "eastus2"
-subscription_id = "930755b1-ef22-4721-a31a-1b6fbecf7da6"
-tenant_id       = "70750cc4-6f21-4c27-bb0e-8b7e66bcb2dd"
+project_name = "arbit"
+env_name     = "prod"
+location     = "eastus2"
 
 tags = {
   project = "arbit"

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -16,11 +16,13 @@ variable "project_name" {
 variable "subscription_id" {
   description = "Azure subscription ID."
   type        = string
+  default     = null
 }
 
 variable "tenant_id" {
   description = "Azure tenant ID."
   type        = string
+  default     = null
 }
 
 variable "tags" {

--- a/platform/infra/envs/stage/providers.tf
+++ b/platform/infra/envs/stage/providers.tf
@@ -7,9 +7,14 @@ terraform {
   }
 }
 
+locals {
+  provider_subscription_id = try(trimspace(var.subscription_id), "") != "" ? var.subscription_id : null
+  provider_tenant_id       = try(trimspace(var.tenant_id), "") != "" ? var.tenant_id : null
+}
+
 provider "azurerm" {
   features {}
 
-  subscription_id = var.subscription_id
-  tenant_id       = var.tenant_id
+  subscription_id = local.provider_subscription_id
+  tenant_id       = local.provider_tenant_id
 }

--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -1,8 +1,6 @@
-project_name    = "arbit"
-env_name        = "stage"
-location        = "eastus"
-subscription_id = "930755b1-ef22-4721-a31a-1b6fbecf7da6"
-tenant_id       = "70750cc4-6f21-4c27-bb0e-8b7e66bcb2dd"
+project_name = "arbit"
+env_name     = "stage"
+location     = "eastus"
 
 tags = {
   project = "arbit"

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -16,11 +16,13 @@ variable "project_name" {
 variable "subscription_id" {
   description = "Azure subscription ID."
   type        = string
+  default     = null
 }
 
 variable "tenant_id" {
   description = "Azure tenant ID."
   type        = string
+  default     = null
 }
 
 variable "tags" {


### PR DESCRIPTION
## Summary
- stop committing subscription and tenant IDs in environment tfvars and let the variables default to null
- update azurerm provider setup to coalesce optional IDs and use pipeline-provided values when present
- wire Azure DevOps templates to load terraform-* variable groups, pass subscription/tenant IDs via `-var`, and document the new variables

## Testing
- `terraform fmt -recursive` *(fails: terraform binary unavailable in container and direct download blocked with HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c881e82eb0832684e7f16fe117500e