### PR TITLE
Remove redundant sql_db_name from env tfvars

### DIFF
--- a/platform/infra/envs/dev/terraform.tfvars
+++ b/platform/infra/envs/dev/terraform.tfvars
@@ -114,7 +114,6 @@ arbitration_app_settings = {
 # SQL Serverless
 # -------------------------
 sql_database_name        = "halomd"
-sql_db_name              = "halomd"
 sql_sku_name             = "GP_S_Gen5_2"
 sql_auto_pause_delay     = 60
 sql_max_size_gb          = 75

--- a/platform/infra/envs/prod/terraform.tfvars
+++ b/platform/infra/envs/prod/terraform.tfvars
@@ -81,7 +81,6 @@ arbitration_app_settings = {
 # -------------------------
 # Support both sql_database_name and sql_db_name for different modules
 sql_database_name        = "halomd"
-sql_db_name              = "halomd"
 
 # Extended config
 sql_sku_name             = "GP_S_Gen5_4"

--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -81,7 +81,6 @@ arbitration_app_settings = {
 # -------------------------
 # Support both sql_database_name and sql_db_name for different modules
 sql_database_name        = "halomd"
-sql_db_name              = "halomd"
 
 # Extended config
 sql_sku_name             = "GP_S_Gen5_2"


### PR DESCRIPTION
## Summary
- remove the sql_db_name key from each environment tfvars file now that sql_database_name is the canonical value

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c88655060c83268827009c3c6a99d8