### PR TITLE
Add optional App Insights resource group override

### DIFF
--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -197,6 +197,15 @@ variable "app_service_connection_strings" {
 }
 
 # -------------------------
+# Monitoring
+# -------------------------
+variable "app_insights_resource_group_name" {
+  description = "Optional resource group where Application Insights resources are created."
+  type        = string
+  default     = null
+}
+
+# -------------------------
 # DNS
 # -------------------------
 variable "dns_zone_name" {

--- a/platform/infra/envs/prod/main.tf
+++ b/platform/infra/envs/prod/main.tf
@@ -115,7 +115,7 @@ module "dns_zone" {
 
 module "app_insights" {
   source                       = "../../Azure/modules/app-insights"
-  resource_group_name          = module.resource_group.name
+  resource_group_name          = coalesce(var.app_insights_resource_group_name, module.resource_group.name)
   location                     = var.location
   log_analytics_workspace_name = local.log_name
   application_insights_name    = local.appi_name

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -196,6 +196,15 @@ variable "app_service_connection_strings" {
 }
 
 # -------------------------
+# Monitoring
+# -------------------------
+variable "app_insights_resource_group_name" {
+  description = "Optional resource group where Application Insights resources are created."
+  type        = string
+  default     = null
+}
+
+# -------------------------
 # DNS
 # -------------------------
 variable "dns_zone_name" {

--- a/platform/infra/envs/stage/main.tf
+++ b/platform/infra/envs/stage/main.tf
@@ -117,7 +117,7 @@ module "dns_zone" {
 
 module "app_insights" {
   source                       = "../../Azure/modules/app-insights"
-  resource_group_name          = module.resource_group.name
+  resource_group_name          = coalesce(var.app_insights_resource_group_name, module.resource_group.name)
   location                     = var.location
   log_analytics_workspace_name = local.log_name
   application_insights_name    = local.appi_name

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -196,6 +196,15 @@ variable "app_service_connection_strings" {
 }
 
 # -------------------------
+# Monitoring
+# -------------------------
+variable "app_insights_resource_group_name" {
+  description = "Optional resource group where Application Insights resources are created."
+  type        = string
+  default     = null
+}
+
+# -------------------------
 # DNS
 # -------------------------
 variable "dns_zone_name" {


### PR DESCRIPTION
## Summary
- add an optional `app_insights_resource_group_name` variable for each environment
- allow stage and prod environments to override the Application Insights resource group when provided

## Testing
- `terraform fmt platform/infra/envs/dev` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8865434a88326a977329760f667a8