### PR TITLE
Add feature toggle variables to environment definitions

### DIFF
--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -32,6 +32,39 @@ variable "tags" {
 }
 
 # -------------------------
+# Feature toggles
+# -------------------------
+variable "enable_acr" {
+  description = "Flag to enable Azure Container Registry provisioning."
+  type        = bool
+  default     = false
+}
+
+variable "enable_sql" {
+  description = "Flag to deploy the SQL Serverless resources."
+  type        = bool
+  default     = false
+}
+
+variable "kv_public_network_access" {
+  description = "Allow public network access to the Key Vault."
+  type        = bool
+  default     = true
+}
+
+variable "enable_aks" {
+  description = "Flag to enable Azure Kubernetes Service provisioning."
+  type        = bool
+  default     = false
+}
+
+variable "enable_storage" {
+  description = "Flag to provision the ancillary storage account resources."
+  type        = bool
+  default     = false
+}
+
+# -------------------------
 # Networking
 # -------------------------
 variable "vnet_address_space" {

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -32,6 +32,39 @@ variable "tags" {
 }
 
 # -------------------------
+# Feature toggles
+# -------------------------
+variable "enable_acr" {
+  description = "Flag to enable Azure Container Registry provisioning."
+  type        = bool
+  default     = false
+}
+
+variable "enable_sql" {
+  description = "Flag to deploy the SQL Serverless resources."
+  type        = bool
+  default     = false
+}
+
+variable "kv_public_network_access" {
+  description = "Allow public network access to the Key Vault."
+  type        = bool
+  default     = true
+}
+
+variable "enable_aks" {
+  description = "Flag to enable Azure Kubernetes Service provisioning."
+  type        = bool
+  default     = false
+}
+
+variable "enable_storage" {
+  description = "Flag to provision the ancillary storage account resources."
+  type        = bool
+  default     = false
+}
+
+# -------------------------
 # Networking
 # -------------------------
 variable "vnet_address_space" {

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -32,6 +32,39 @@ variable "tags" {
 }
 
 # -------------------------
+# Feature toggles
+# -------------------------
+variable "enable_acr" {
+  description = "Flag to enable Azure Container Registry provisioning."
+  type        = bool
+  default     = false
+}
+
+variable "enable_sql" {
+  description = "Flag to deploy the SQL Serverless resources."
+  type        = bool
+  default     = false
+}
+
+variable "kv_public_network_access" {
+  description = "Allow public network access to the Key Vault."
+  type        = bool
+  default     = true
+}
+
+variable "enable_aks" {
+  description = "Flag to enable Azure Kubernetes Service provisioning."
+  type        = bool
+  default     = false
+}
+
+variable "enable_storage" {
+  description = "Flag to provision the ancillary storage account resources."
+  type        = bool
+  default     = false
+}
+
+# -------------------------
 # Networking
 # -------------------------
 variable "vnet_address_space" {


### PR DESCRIPTION
## Summary
- add boolean feature toggle variables for optional services in the dev, stage, and prod environment variable definitions
- default the new toggles to false (and keep Key Vault public access enabled) to match existing configuration usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c886529d2c83269e61c627a9641819