### PR TITLE
Consolidate app gateway backend host configuration

### DIFF
--- a/platform/infra/envs/dev/main.tf
+++ b/platform/infra/envs/dev/main.tf
@@ -88,12 +88,14 @@ module "app_service_arbitration" {
 }
 
 locals {
+  default_app_gateway_backend_fqdns = compact([
+    module.app_service.default_hostname,
+    module.app_service_arbitration.default_hostname,
+  ])
+
   app_gateway_backend_fqdns = distinct(compact(concat(
     var.app_gateway_backend_fqdns,
-    [
-      module.app_service.default_hostname,
-      module.app_service_arbitration.default_hostname,
-    ],
+    local.default_app_gateway_backend_fqdns,
   )))
 
   dns_hostname_overrides = {

--- a/platform/infra/envs/dev/terraform.tfvars
+++ b/platform/infra/envs/dev/terraform.tfvars
@@ -28,10 +28,6 @@ app_gateway_subnet_key = "gateway"
 
 app_gateway_fqdn_prefix = "agw-arbit-dev"
 app_gateway_backend_fqdns = []
-app_gateway_backend_hostnames = [
-  "web-arbit-dev.azurewebsites.net",
-  "web-arbit-dev-arb.azurewebsites.net",
-]
 
 # -------------------------
 # DNS

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -85,11 +85,6 @@ variable "app_gateway_backend_fqdns" {
   default     = []
 }
 
-variable "app_gateway_backend_hostnames" {
-  description = "List of backend hostnames for the Application Gateway."
-  type        = list(string)
-}
-
 variable "app_gateway_backend_port" {
   description = "Backend port used by the Application Gateway."
   type        = number

--- a/platform/infra/envs/prod/terraform.tfvars
+++ b/platform/infra/envs/prod/terraform.tfvars
@@ -27,9 +27,8 @@ app_gateway_subnet_key  = "gateway"
 # For module using direct subnet id
 app_gateway_subnet_id = "/subscriptions/930755b1-ef22-4721-a31a-1b6fbecf7da6/resourceGroups/rg-arbit-prod/providers/Microsoft.Network/virtualNetworks/vnet-arbit-prod/subnets/appgw"
 
-app_gateway_fqdn_prefix    = "agw-arbit-prod"
-app_gateway_backend_fqdns  = []
-app_gateway_backend_hostnames = [
+app_gateway_fqdn_prefix   = "agw-arbit-prod"
+app_gateway_backend_fqdns = [
   "app-halomdweb-prod.azurewebsites.net",
   "app-arbit-arb-prod.azurewebsites.net",
 ]

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -84,11 +84,6 @@ variable "app_gateway_backend_fqdns" {
   default     = []
 }
 
-variable "app_gateway_backend_hostnames" {
-  description = "List of backend hostnames for the Application Gateway."
-  type        = list(string)
-}
-
 variable "app_gateway_backend_port" {
   description = "Backend port used by the Application Gateway."
   type        = number

--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -27,9 +27,8 @@ app_gateway_subnet_key  = "gateway"
 # For module using direct subnet id
 app_gateway_subnet_id = "/subscriptions/930755b1-ef22-4721-a31a-1b6fbecf7da6/resourceGroups/rg-arbit-stage/providers/Microsoft.Network/virtualNetworks/vnet-arbit-stage/subnets/appgw"
 
-app_gateway_fqdn_prefix    = "agw-arbit-stage"
-app_gateway_backend_fqdns  = []
-app_gateway_backend_hostnames = [
+app_gateway_fqdn_prefix   = "agw-arbit-stage"
+app_gateway_backend_fqdns = [
   "app-halomdweb-stage.azurewebsites.net",
   "app-arbit-arb-stage.azurewebsites.net",
 ]

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -84,11 +84,6 @@ variable "app_gateway_backend_fqdns" {
   default     = []
 }
 
-variable "app_gateway_backend_hostnames" {
-  description = "List of backend hostnames for the Application Gateway."
-  type        = list(string)
-}
-
 variable "app_gateway_backend_port" {
   description = "Backend port used by the Application Gateway."
   type        = number


### PR DESCRIPTION
## Summary
- standardize on the `app_gateway_backend_fqdns` input and merge it with default hostnames in the dev environment
- remove the unused `app_gateway_backend_hostnames` variable and migrate tfvars entries to `app_gateway_backend_fqdns`

## Testing
- Not run (terraform CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c88653f76c8326a13b27a781c8c3f9