### PR TITLE
chore: expand gitignore for Terraform and dev files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,20 @@
-
+# Terraform local files
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+crash.log
+crash.*.log
+*.tfvars
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+*.tfplan
 **/.terraform.lock.hcl
 
+# Editor directories
+.vscode/
+.idea/
 
+# OS metadata
+.DS_Store


### PR DESCRIPTION
## Summary
- broaden `.gitignore` to exclude Terraform state, lock, and plan files
- add ignores for local editor and OS-specific artifacts

## Testing
- `terraform version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c88575b880832686c45b07907299ec