### PR TITLE
Add Application Insights name variable to environment configs

### DIFF
--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -233,6 +233,12 @@ variable "app_insights_resource_group_name" {
   default     = null
 }
 
+variable "app_insights_name" {
+  description = "Optional name override for the Application Insights resource."
+  type        = string
+  default     = ""
+}
+
 # -------------------------
 # DNS
 # -------------------------

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -232,6 +232,12 @@ variable "app_insights_resource_group_name" {
   default     = null
 }
 
+variable "app_insights_name" {
+  description = "Optional name override for the Application Insights resource."
+  type        = string
+  default     = ""
+}
+
 # -------------------------
 # DNS
 # -------------------------

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -232,6 +232,12 @@ variable "app_insights_resource_group_name" {
   default     = null
 }
 
+variable "app_insights_name" {
+  description = "Optional name override for the Application Insights resource."
+  type        = string
+  default     = ""
+}
+
 # -------------------------
 # DNS
 # -------------------------


### PR DESCRIPTION
## Summary
- add an optional Application Insights name variable to the dev environment configuration
- mirror the Application Insights name variable in the stage and prod environment configurations

## Testing
- not run (terraform configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68c8888c86b88326841992b40c4223e0