### PR TITLE
Remove unused AKS and storage toggles

### DIFF
--- a/platform/infra/envs/dev/terraform.tfvars
+++ b/platform/infra/envs/dev/terraform.tfvars
@@ -66,9 +66,7 @@ app_service_connection_strings = {
 # -------------------------
 # Feature flags
 # -------------------------
-enable_aks      = false
 enable_acr      = false
-enable_storage  = false
 enable_sql      = true
 kv_public_network_access = true
 

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -52,18 +52,6 @@ variable "kv_public_network_access" {
   default     = true
 }
 
-variable "enable_aks" {
-  description = "Flag to enable Azure Kubernetes Service provisioning."
-  type        = bool
-  default     = false
-}
-
-variable "enable_storage" {
-  description = "Flag to provision the ancillary storage account resources."
-  type        = bool
-  default     = false
-}
-
 # -------------------------
 # Networking
 # -------------------------

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -52,18 +52,6 @@ variable "kv_public_network_access" {
   default     = true
 }
 
-variable "enable_aks" {
-  description = "Flag to enable Azure Kubernetes Service provisioning."
-  type        = bool
-  default     = false
-}
-
-variable "enable_storage" {
-  description = "Flag to provision the ancillary storage account resources."
-  type        = bool
-  default     = false
-}
-
 # -------------------------
 # Networking
 # -------------------------

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -52,18 +52,6 @@ variable "kv_public_network_access" {
   default     = true
 }
 
-variable "enable_aks" {
-  description = "Flag to enable Azure Kubernetes Service provisioning."
-  type        = bool
-  default     = false
-}
-
-variable "enable_storage" {
-  description = "Flag to provision the ancillary storage account resources."
-  type        = bool
-  default     = false
-}
-
 # -------------------------
 # Networking
 # -------------------------


### PR DESCRIPTION
## Summary
- remove the unused `enable_aks` and `enable_storage` variables from each environment's root module
- stop defining the unused AKS and storage flags in the dev `terraform.tfvars`

## Testing
- not run (terraform CLI not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c888933888832680e14791ee2abfe1