### PR TITLE
Rename negotiation notice deadline null data test

### DIFF
--- a/tests/TestArbitApi/UnitTest_NegotiationNoticeDeadline.cs
+++ b/tests/TestArbitApi/UnitTest_NegotiationNoticeDeadline.cs
@@ -51,7 +51,7 @@ namespace TestArbitApi
             Assert.Null(arb.NegotiationNoticeDeadline);
         }
         [Fact]
-        public void TestNegotiationNoticeDeadline_NulData()
+        public void TestNegotiationNoticeDeadline_NullData()
         {
             string JSONDataBad = "{}";
             var arb = new ArbitrationCase();


### PR DESCRIPTION
## Summary
- rename the negotiation notice deadline null data unit test to fix the typo in its name

## Testing
- dotnet test tests/TestArbitApi/Tests.csproj *(fails: dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c88b458cd883268fe4fb508dc690d4