### PR TITLE
Fix module outputs to reference correct resource IDs

### DIFF
--- a/platform/infra/Azure/modules/linux-virtual-machine/outputs.tf
+++ b/platform/infra/Azure/modules/linux-virtual-machine/outputs.tf
@@ -1,3 +1,3 @@
 output "id" {
-  value = azurerm_lb.this.id
+  value = azurerm_linux_virtual_machine.this.id
 }

--- a/platform/infra/Azure/modules/linux-web-app/outputs.tf
+++ b/platform/infra/Azure/modules/linux-web-app/outputs.tf
@@ -1,3 +1,3 @@
 output "id" {
-  value = azurerm_lb.this.id
+  value = azurerm_linux_web_app.this.id
 }

--- a/platform/infra/Azure/modules/managed-disk/outputs.tf
+++ b/platform/infra/Azure/modules/managed-disk/outputs.tf
@@ -1,3 +1,3 @@
 output "id" {
-  value = azurerm_lb.this.id
+  value = azurerm_managed_disk.this.id
 }

--- a/platform/infra/Azure/modules/mssql-database/outputs.tf
+++ b/platform/infra/Azure/modules/mssql-database/outputs.tf
@@ -1,3 +1,3 @@
 output "id" {
-  value = azurerm_lb.this.id
+  value = azurerm_mssql_database.this.id
 }

--- a/platform/infra/Azure/modules/mssql-server/outputs.tf
+++ b/platform/infra/Azure/modules/mssql-server/outputs.tf
@@ -1,3 +1,3 @@
 output "id" {
-  value = azurerm_lb.this.id
+  value = azurerm_mssql_server.this.id
 }

--- a/platform/infra/Azure/modules/network-security-group/outputs.tf
+++ b/platform/infra/Azure/modules/network-security-group/outputs.tf
@@ -1,3 +1,3 @@
 output "id" {
-  value = azurerm_lb.this.id
+  value = azurerm_network_security_group.this.id
 }

--- a/platform/infra/Azure/modules/storage-container/outputs.tf
+++ b/platform/infra/Azure/modules/storage-container/outputs.tf
@@ -1,3 +1,3 @@
 output "id" {
-  value = azurerm_lb.this.id
+  value = azurerm_storage_container.this.id
 }

--- a/platform/infra/Azure/modules/virtual-machine-data-disk-attachment/outputs.tf
+++ b/platform/infra/Azure/modules/virtual-machine-data-disk-attachment/outputs.tf
@@ -1,3 +1,3 @@
 output "id" {
-  value = azurerm_lb.this.id
+  value = azurerm_virtual_machine_data_disk_attachment.this.id
 }


### PR DESCRIPTION
## Summary
- correct the `id` outputs in Azure modules so they reference each module's primary resource instead of `azurerm_lb`
- ensure storage, compute, database, and security modules now expose the appropriate resource identifiers

## Testing
- terraform validate *(fails: Terraform CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c88b3cc194832696e8c64911a4b3f0