### PR TITLE
Define module variable types and document defaults

### DIFF
--- a/platform/infra/Azure/modules/mssql-database/README.md
+++ b/platform/infra/Azure/modules/mssql-database/README.md
@@ -1,0 +1,10 @@
+# mssql-database module
+
+Creates an Azure SQL (MSSQL) database instance.
+
+## Inputs
+
+- `name` (`string`, required) – Name of the database resource.
+- `server_id` (`string`, required) – Resource ID of the SQL server that hosts the database.
+- `sku_name` (`string`, required) – SKU to provision for the database (for example `S0`, `GP_S_Gen5_2`).
+

--- a/platform/infra/Azure/modules/mssql-database/variables.tf
+++ b/platform/infra/Azure/modules/mssql-database/variables.tf
@@ -1,8 +1,11 @@
-variable "name" {}
+variable "name" {
+  type = string
+}
 
 variable "server_id" {
-  default = ""
+  type = string
 }
+
 variable "sku_name" {
-  default = ""
+  type = string
 }

--- a/platform/infra/Azure/modules/storage-container/README.md
+++ b/platform/infra/Azure/modules/storage-container/README.md
@@ -1,0 +1,9 @@
+# storage-container module
+
+Provisions a container within an existing Azure Storage account.
+
+## Inputs
+
+- `name` (`string`, required) – Name of the storage container.
+- `access_type` (`string`, optional, default `private`) – Access level for the container (for example `private`, `blob`, or `container`).
+

--- a/platform/infra/Azure/modules/storage-container/variables.tf
+++ b/platform/infra/Azure/modules/storage-container/variables.tf
@@ -1,4 +1,8 @@
-variable "name" {}
+variable "name" {
+  type = string
+}
+
 variable "access_type" {
-  default = ""
+  type    = string
+  default = "private"
 }


### PR DESCRIPTION
## Summary
- declare explicit string types for the MSSQL database and storage container module variables and drop empty-string defaults
- keep the storage container access type optional with a documented `private` fallback value
- add lightweight READMEs for both modules to call out the required inputs and defaults

## Testing
- `terraform fmt` *(fails: terraform binary not available in container)*


------
https://chatgpt.com/codex/tasks/task_e_68c88b41e8548326ae0fe642ed6f4335