### PR TITLE
Add storage account input to storage container module

### DIFF
--- a/platform/infra/Azure/modules/storage-container/README.md
+++ b/platform/infra/Azure/modules/storage-container/README.md
@@ -5,5 +5,6 @@ Provisions a container within an existing Azure Storage account.
 ## Inputs
 
 - `name` (`string`, required) – Name of the storage container.
+- `storage_account_name` (`string`, required) – Name of the storage account that hosts the container.
 - `access_type` (`string`, optional, default `private`) – Access level for the container (for example `private`, `blob`, or `container`).
 

--- a/platform/infra/Azure/modules/storage-container/main.tf
+++ b/platform/infra/Azure/modules/storage-container/main.tf
@@ -1,4 +1,5 @@
 resource "azurerm_storage_container" "this" {
   name                  = var.name
+  storage_account_name  = var.storage_account_name
   container_access_type = var.access_type
 }

--- a/platform/infra/Azure/modules/storage-container/variables.tf
+++ b/platform/infra/Azure/modules/storage-container/variables.tf
@@ -2,6 +2,10 @@ variable "name" {
   type = string
 }
 
+variable "storage_account_name" {
+  type = string
+}
+
 variable "access_type" {
   type    = string
   default = "private"


### PR DESCRIPTION
## Summary
- add a new `storage_account_name` input variable for the storage container module
- propagate the storage account name to the `azurerm_storage_container` resource
- document the new input in the module README

## Testing
- not run (Terraform CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c890eb75b48326b4bed293fbcdd557