### PR TITLE
Allow configuring blob public access on storage accounts

### DIFF
--- a/platform/infra/Azure/modules/storage-account/main.tf
+++ b/platform/infra/Azure/modules/storage-account/main.tf
@@ -5,6 +5,7 @@ resource "azurerm_storage_account" "sa" {
   account_tier             = var.account_tier
   account_replication_type = var.replication_type
   account_kind             = "StorageV2"
+  allow_blob_public_access = var.allow_blob_public_access
   is_hns_enabled           = var.enable_hns
   min_tls_version          = var.min_tls_version
   tags                     = var.tags

--- a/platform/infra/Azure/modules/storage-account/variables.tf
+++ b/platform/infra/Azure/modules/storage-account/variables.tf
@@ -11,6 +11,7 @@ variable "replication_type" {
 }
 
 variable "allow_blob_public_access" {
+  description = "Controls whether anonymous public access to blob data is permitted."
   type    = bool
   default = false
 }


### PR DESCRIPTION
## Summary
- add the storage account module option to set allow_blob_public_access
- describe the allow_blob_public_access variable while keeping it a boolean

## Testing
- not run (terraform CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c890ee7d0883269c7a6680e39c14ea