### PR TITLE
Require network interface input for Linux VM module

### DIFF
--- a/platform/infra/Azure/modules/linux-virtual-machine/variables.tf
+++ b/platform/infra/Azure/modules/linux-virtual-machine/variables.tf
@@ -3,5 +3,11 @@ variable "location" {}
 variable "resource_group_name" {}
 variable "sku" { default = "Standard" }
 variable "nic_id" {
-  default = ""
+  description = "Resource ID of the primary network interface to attach to the VM."
+  type        = string
+
+  validation {
+    condition     = can(regex("^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\\.Network/networkInterfaces/[^/]+$", trimspace(var.nic_id)))
+    error_message = "nic_id must be a valid Azure resource ID for a network interface."
+  }
 }


### PR DESCRIPTION
## Summary
- require the linux virtual machine module to accept a NIC resource ID input
- validate the provided NIC ID matches the expected Azure resource identifier format

## Testing
- terraform fmt platform/infra/Azure/modules/linux-virtual-machine/variables.tf *(fails: terraform executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c890f762c083269b2312ccd989b11f