### PR TITLE
Require SQL admin credentials

### DIFF
--- a/platform/infra/Azure/modules/sql-database/variables.tf
+++ b/platform/infra/Azure/modules/sql-database/variables.tf
@@ -11,11 +11,9 @@ variable "location" {
 }
 variable "admin_login" {
   type    = string
-  default = ""
 }
 variable "admin_password" {
   type      = string
-  default   = ""
   sensitive = true
 }
 variable "public_network_access_enabled" {

--- a/platform/infra/Azure/modules/sql-serverless/variables.tf
+++ b/platform/infra/Azure/modules/sql-serverless/variables.tf
@@ -22,14 +22,12 @@ variable "location" {
 variable "administrator_login" {
   description = "Administrator login for the SQL Server."
   type        = string
-  default     = ""
 }
 
 variable "administrator_password" {
   description = "Administrator password for the SQL Server."
   type        = string
   sensitive   = true
-  default     = ""
 }
 
 variable "public_network_access_enabled" {


### PR DESCRIPTION
## Summary
- remove empty string defaults from SQL admin login and password variables in the database module
- remove empty string defaults from SQL administrator login and password variables in the serverless module to make them required inputs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c891d86b708326a890500ce8cf81f4