### PR TITLE
Refactor negotiation notice deadline tests to use theories

### DIFF
--- a/tests/TestArbitApi/UnitTest_NegotiationNoticeDeadline.cs
+++ b/tests/TestArbitApi/UnitTest_NegotiationNoticeDeadline.cs
@@ -4,66 +4,67 @@ namespace TestArbitApi
 {
     public class UnitTest_NegotiationNoticeDeadline
     {
-        string JSONData = "{\"NegotiationNoticeDeadline\":\"2022-06-07T06:00:00+00:00\",\"DateNegotiationSent\":\"2022-04-12T06:00:00+00:00\",\"NegotiationDeadline\":\"2022-05-23T06:00:00+00:00\",\"ArbitrationFilingStartDate\":\"2022-05-24T06:00:00+00:00\",\"ArbitrationFilingDeadline\":\"2022-05-27T06:00:00+00:00\",\"SubmittedToAuthority\":null,\"PayorAcceptanceDeadline\":null,\"ArbitratorSelectionDeadline\":null,\"ArbitratorAssignedOn\":null,\"NoConflictConfirmationDeadline\":null,\"ArbitrationBriefDueOn\":null,\"ArbitrationFeeDeadline\":null,\"AuthorityResolutionDeadline\":null,\"DateDecisionWasMade\":null,\"PaymentDeadlineIfWon\":null,\"ArbitrationFeeRefundDeadline\":null}";
-        [Fact]
-        public void TestNegotiationNoticeDeadline_WithDateInCorrectFormatInJsonData()
+        private const string ValidTrackingJson =
+            "{\"NegotiationNoticeDeadline\":\"2022-06-07T06:00:00+00:00\"," +
+            "\"DateNegotiationSent\":\"2022-04-12T06:00:00+00:00\"," +
+            "\"NegotiationDeadline\":\"2022-05-23T06:00:00+00:00\"," +
+            "\"ArbitrationFilingStartDate\":\"2022-05-24T06:00:00+00:00\"," +
+            "\"ArbitrationFilingDeadline\":\"2022-05-27T06:00:00+00:00\"," +
+            "\"SubmittedToAuthority\":null,\"PayorAcceptanceDeadline\":null," +
+            "\"ArbitratorSelectionDeadline\":null,\"ArbitratorAssignedOn\":null," +
+            "\"NoConflictConfirmationDeadline\":null,\"ArbitrationBriefDueOn\":null," +
+            "\"ArbitrationFeeDeadline\":null,\"AuthorityResolutionDeadline\":null," +
+            "\"DateDecisionWasMade\":null,\"PaymentDeadlineIfWon\":null," +
+            "\"ArbitrationFeeRefundDeadline\":null}";
+
+        private const string InvalidDateTrackingJson =
+            "{\"NegotiationNoticeDeadline\":\"202-06-07T06:00:00+00:00\"}";
+
+        [Theory]
+        [InlineData(ValidTrackingJson, "2022-06-07")]
+        public void NegotiationNoticeDeadline_WithDateInJson_AssignsParsedDate(string json, string expectedDate)
         {
             var arb = new ArbitrationCase();
-            arb.NSATracking = JSONData;
-            Assert.Equal("2022-06-07", arb.NegotiationNoticeDeadline!.Value.ToString("yyyy-MM-dd"));
+
+            arb.NSATracking = json;
+
+            Assert.Equal(expectedDate, arb.NegotiationNoticeDeadline!.Value.ToString("yyyy-MM-dd"));
         }
-        [Fact]
-        public void TestNegotiationNoticeDeadline_EmptyJSONShouldPickEOBDate()
+
+        [Theory]
+        [InlineData("", "2024-07-01")]
+        [InlineData(null, "2024-07-01")]
+        public void NegotiationNoticeDeadline_WhenJsonMissing_UsesEobDate(string? json, string eobDate)
         {
-            var arb = new ArbitrationCase() { EOBDate = DateTime.Parse("2024-07-01") };
-            arb.NSATracking = "";
-            Assert.Equal(arb.EOBDate.Value.AddDays(29).ToString("yyyy-MM-dd"), arb.NegotiationNoticeDeadline!.Value.ToString("yyyy-MM-dd"));
+            var eobDateValue = DateTime.Parse(eobDate);
+            var arb = new ArbitrationCase { EOBDate = eobDateValue };
+
+            arb.NSATracking = json;
+
+            Assert.Equal(eobDateValue.AddDays(29).ToString("yyyy-MM-dd"), arb.NegotiationNoticeDeadline!.Value.ToString("yyyy-MM-dd"));
         }
-        [Fact]
-        public void TestNegotiationNoticeDeadline_BadFormatStringDateFormatException()
+
+        [Theory]
+        [InlineData(InvalidDateTrackingJson)]
+        public void NegotiationNoticeDeadline_WithInvalidDate_ThrowsFormatException(string json)
         {
-            string JSONDataBad = "{\"NegotiationNoticeDeadline\":\"202-06-07T06:00:00+00:00\",}";
             var arb = new ArbitrationCase();
-            Assert.Throws<FormatException>(() => arb.NSATracking = JSONDataBad);
+
+            Assert.Throws<FormatException>(() => arb.NSATracking = json);
         }
-        [Fact]
-        public void TestNegotiationNoticeDeadline_NullAsValue()
+
+        [Theory]
+        [InlineData("{\"NegotiationNoticeDeadline\":null}")]
+        [InlineData("{\"NegotiationNoticeDeadline\":\"\"}")]
+        [InlineData("{}")]
+        [InlineData(null)]
+        [InlineData("")]
+        public void NegotiationNoticeDeadline_WhenValueMissing_ReturnsNull(string? json)
         {
-            string JSONDataBad = "{\"NegotiationNoticeDeadline\":null,}";
             var arb = new ArbitrationCase();
-            arb.NSATracking = JSONDataBad;
-            Assert.Null(arb.NegotiationNoticeDeadline);
-        }
-        [Fact]
-        public void TestNegotiationNoticeDeadline_Empty()
-        {
-            string JSONDataBad = "{\"NegotiationNoticeDeadline\":\"\",}";
-            var arb = new ArbitrationCase();
-            arb.NSATracking = JSONDataBad;
-            Assert.Null(arb.NegotiationNoticeDeadline);
-        }
-        [Fact]
-        public void TestNegotiationNoticeDeadline_NoValue()
-        {
-            string JSONDataBad = "{}";
-            var arb = new ArbitrationCase();
-            arb.NSATracking = JSONDataBad;
-            Assert.Null(arb.NegotiationNoticeDeadline);
-        }
-        [Fact]
-        public void TestNegotiationNoticeDeadline_NullData()
-        {
-            string JSONDataBad = "{}";
-            var arb = new ArbitrationCase();
-            arb.NSATracking = null;
-            Assert.Null(arb.NegotiationNoticeDeadline);
-        }
-        [Fact]
-        public void TestNegotiationNoticeDeadline_EmptyStringAsData()
-        {
-            string JSONDataBad = "{}";
-            var arb = new ArbitrationCase();
-            arb.NSATracking = string.Empty;
+
+            arb.NSATracking = json;
+
             Assert.Null(arb.NegotiationNoticeDeadline);
         }
     }


### PR DESCRIPTION
## Summary
- refactor the negotiation notice deadline tests to use xUnit theories with inline data
- cover valid, fallback, invalid, and null tracking JSON scenarios without duplicated facts

## Testing
- dotnet test tests/TestArbitApi/Tests.csproj *(fails in container: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c891de28e0832685359b56b4e21159