### PR TITLE
Refine VM data disk attachment variable types

### DIFF
--- a/platform/infra/Azure/modules/virtual-machine-data-disk-attachment/variables.tf
+++ b/platform/infra/Azure/modules/virtual-machine-data-disk-attachment/variables.tf
@@ -1,9 +1,11 @@
 variable "disk_id" {
-  default = ""
+  type = string
 }
+
 variable "vm_id" {
-  default = ""
+  type = string
 }
+
 variable "lun" {
-  default = ""
+  type = number
 }


### PR DESCRIPTION
## Summary
- define `disk_id` and `vm_id` as string variables
- declare the `lun` variable as a number
- remove default values so these variables are required

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68c8932386188326a8bb543055852bbf