### PR TITLE
Make Linux VM NIC input required

### DIFF
--- a/platform/infra/Azure/modules/linux-virtual-machine/variables.tf
+++ b/platform/infra/Azure/modules/linux-virtual-machine/variables.tf
@@ -5,6 +5,7 @@ variable "sku" { default = "Standard" }
 variable "nic_id" {
   description = "Resource ID of the primary network interface to attach to the VM."
   type        = string
+  nullable    = false
 
   validation {
     condition     = can(regex("^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\\.Network/networkInterfaces/[^/]+$", trimspace(var.nic_id)))


### PR DESCRIPTION
## Summary
- make the linux virtual machine module's `nic_id` input explicitly required so it cannot be omitted

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c89327c1008326bbec949f097a7df7