### PR TITLE
Enforce SQL admin credentials input

### DIFF
--- a/platform/infra/Azure/modules/sql-database/variables.tf
+++ b/platform/infra/Azure/modules/sql-database/variables.tf
@@ -10,11 +10,23 @@ variable "location" {
   type = string
 }
 variable "admin_login" {
-  type    = string
+  description = "Administrator login for the SQL server."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.admin_login)) > 0
+    error_message = "Administrator login must be provided."
+  }
 }
 variable "admin_password" {
-  type      = string
-  sensitive = true
+  description = "Administrator password for the SQL server."
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = length(trimspace(var.admin_password)) > 0
+    error_message = "Administrator password must be provided."
+  }
 }
 variable "public_network_access_enabled" {
   type    = bool

--- a/platform/infra/Azure/modules/sql-serverless/variables.tf
+++ b/platform/infra/Azure/modules/sql-serverless/variables.tf
@@ -22,12 +22,22 @@ variable "location" {
 variable "administrator_login" {
   description = "Administrator login for the SQL Server."
   type        = string
+
+  validation {
+    condition     = length(trimspace(var.administrator_login)) > 0
+    error_message = "Administrator login must be provided."
+  }
 }
 
 variable "administrator_password" {
   description = "Administrator password for the SQL Server."
   type        = string
   sensitive   = true
+
+  validation {
+    condition     = length(trimspace(var.administrator_password)) > 0
+    error_message = "Administrator password must be provided."
+  }
 }
 
 variable "public_network_access_enabled" {


### PR DESCRIPTION
## Summary
- mark the SQL database module admin login/password variables as required inputs with descriptions
- add validation to both modules to reject empty admin logins and passwords

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c89319eda08326ac8553ef45f9af39