### PR TITLE
Require application gateway subnet ID in dev environment

### DIFF
--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -89,7 +89,6 @@ variable "app_gateway_subnet_key" {
 variable "app_gateway_subnet_id" {
   description = "Subnet resource ID for the Application Gateway."
   type        = string
-  default     = ""
 }
 
 # -------------------------


### PR DESCRIPTION
## Summary
- remove the empty-string default from the Application Gateway subnet ID variable in the dev environment so callers must supply a value

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8931940388326859bc171aecce783