### PR TITLE
Optimize MPArbitration Dockerfile runtime image

### DIFF
--- a/Arbitration/MPArbitration/Dockerfile.linux
+++ b/Arbitration/MPArbitration/Dockerfile.linux
@@ -1,36 +1,29 @@
-#FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
-#EXPOSE 443
 ENV ASPNETCORE_URLS=http://+:80;
-#ENV ASPNETCORE_URLS=http://+:80;https://+:443
 
-RUN apt-get update
-RUN apt-get -y install build-essential nodejs npm
-RUN npm --version
-RUN apt-get update
-
-
-
-#FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:6.0 AS build
-
 WORKDIR /src
-COPY ["MPArbitration.csproj", "."]
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential nodejs npm \
+    && rm -rf /var/lib/apt/lists/*
+RUN npm --version
+
+COPY ["MPArbitration.csproj", "."]
 RUN dotnet restore "./MPArbitration.csproj"
 COPY . .
 WORKDIR "/src/."
 
 ARG configuration=Release
 RUN dotnet build "MPArbitration.csproj" -c $configuration -o /app/build
+
 FROM build AS publish
 ARG configuration=Release
 RUN dotnet publish "MPArbitration.csproj" -c $configuration -o /app/publish /p:UseAppHost=false
 
 FROM base AS final
-
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "MPArbitration.dll"]


### PR DESCRIPTION
## Summary
- switch the runtime base image to mcr.microsoft.com/dotnet/aspnet:6.0 while keeping the SDK for build stages
- install build tooling and node dependencies only during the build stage and clean apt caches
- keep the final image lean by copying only published runtime assets into the runtime stage

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8931701fc8326a98a814a1e069360