### PR TITLE
Refactor negotiation notice deadline tests to theory

### DIFF
--- a/tests/TestArbitApi/UnitTest_NegotiationNoticeDeadline.cs
+++ b/tests/TestArbitApi/UnitTest_NegotiationNoticeDeadline.cs
@@ -1,70 +1,52 @@
+using System;
+using System.Collections.Generic;
 using MPArbitration.Model;
 
 namespace TestArbitApi
 {
     public class UnitTest_NegotiationNoticeDeadline
     {
-        string JSONData = "{\"NegotiationNoticeDeadline\":\"2022-06-07T06:00:00+00:00\",\"DateNegotiationSent\":\"2022-04-12T06:00:00+00:00\",\"NegotiationDeadline\":\"2022-05-23T06:00:00+00:00\",\"ArbitrationFilingStartDate\":\"2022-05-24T06:00:00+00:00\",\"ArbitrationFilingDeadline\":\"2022-05-27T06:00:00+00:00\",\"SubmittedToAuthority\":null,\"PayorAcceptanceDeadline\":null,\"ArbitratorSelectionDeadline\":null,\"ArbitratorAssignedOn\":null,\"NoConflictConfirmationDeadline\":null,\"ArbitrationBriefDueOn\":null,\"ArbitrationFeeDeadline\":null,\"AuthorityResolutionDeadline\":null,\"DateDecisionWasMade\":null,\"PaymentDeadlineIfWon\":null,\"ArbitrationFeeRefundDeadline\":null}";
-        [Fact]
-        public void TestNegotiationNoticeDeadline_WithDateInCorrectFormatInJsonData()
+        private const string ValidNegotiationNoticeDeadlineJson = "{\"NegotiationNoticeDeadline\":\"2022-06-07T06:00:00+00:00\",\"DateNegotiationSent\":\"2022-04-12T06:00:00+00:00\",\"NegotiationDeadline\":\"2022-05-23T06:00:00+00:00\",\"ArbitrationFilingStartDate\":\"2022-05-24T06:00:00+00:00\",\"ArbitrationFilingDeadline\":\"2022-05-27T06:00:00+00:00\",\"SubmittedToAuthority\":null,\"PayorAcceptanceDeadline\":null,\"ArbitratorSelectionDeadline\":null,\"ArbitratorAssignedOn\":null,\"NoConflictConfirmationDeadline\":null,\"ArbitrationBriefDueOn\":null,\"ArbitrationFeeDeadline\":null,\"AuthorityResolutionDeadline\":null,\"DateDecisionWasMade\":null,\"PaymentDeadlineIfWon\":null,\"ArbitrationFeeRefundDeadline\":null}";
+
+        public static IEnumerable<object?[]> NegotiationNoticeDeadlineData => new[]
+        {
+            new object?[] { ValidNegotiationNoticeDeadlineJson, null, "2022-06-07", null },
+            new object?[] { string.Empty, "2024-07-01", "2024-07-30", null },
+            new object?[] { "{\"NegotiationNoticeDeadline\":null,}", null, null, null },
+            new object?[] { "{\"NegotiationNoticeDeadline\":\"\",}", null, null, null },
+            new object?[] { "{}", null, null, null },
+            new object?[] { null, null, null, null },
+            new object?[] { string.Empty, null, null, null },
+            new object?[] { "{\"NegotiationNoticeDeadline\":\"202-06-07T06:00:00+00:00\",}", null, null, typeof(FormatException) },
+        };
+
+        [Theory]
+        [MemberData(nameof(NegotiationNoticeDeadlineData))]
+        public void TestNegotiationNoticeDeadline(string? jsonData, string? eobDate, string? expectedDeadline, Type? expectedException)
         {
             var arb = new ArbitrationCase();
-            arb.NSATracking = JSONData;
-            Assert.Equal("2022-06-07", arb.NegotiationNoticeDeadline!.Value.ToString("yyyy-MM-dd"));
-        }
-        [Fact]
-        public void TestNegotiationNoticeDeadline_EmptyJSONShouldPickEOBDate()
-        {
-            var arb = new ArbitrationCase() { EOBDate = DateTime.Parse("2024-07-01") };
-            arb.NSATracking = "";
-            Assert.Equal(arb.EOBDate.Value.AddDays(29).ToString("yyyy-MM-dd"), arb.NegotiationNoticeDeadline!.Value.ToString("yyyy-MM-dd"));
-        }
-        [Fact]
-        public void TestNegotiationNoticeDeadline_BadFormatStringDateFormatException()
-        {
-            string JSONDataBad = "{\"NegotiationNoticeDeadline\":\"202-06-07T06:00:00+00:00\",}";
-            var arb = new ArbitrationCase();
-            Assert.Throws<FormatException>(() => arb.NSATracking = JSONDataBad);
-        }
-        [Fact]
-        public void TestNegotiationNoticeDeadline_NullAsValue()
-        {
-            string JSONDataBad = "{\"NegotiationNoticeDeadline\":null,}";
-            var arb = new ArbitrationCase();
-            arb.NSATracking = JSONDataBad;
-            Assert.Null(arb.NegotiationNoticeDeadline);
-        }
-        [Fact]
-        public void TestNegotiationNoticeDeadline_Empty()
-        {
-            string JSONDataBad = "{\"NegotiationNoticeDeadline\":\"\",}";
-            var arb = new ArbitrationCase();
-            arb.NSATracking = JSONDataBad;
-            Assert.Null(arb.NegotiationNoticeDeadline);
-        }
-        [Fact]
-        public void TestNegotiationNoticeDeadline_NoValue()
-        {
-            string JSONDataBad = "{}";
-            var arb = new ArbitrationCase();
-            arb.NSATracking = JSONDataBad;
-            Assert.Null(arb.NegotiationNoticeDeadline);
-        }
-        [Fact]
-        public void TestNegotiationNoticeDeadline_NullData()
-        {
-            string JSONDataBad = "{}";
-            var arb = new ArbitrationCase();
-            arb.NSATracking = null;
-            Assert.Null(arb.NegotiationNoticeDeadline);
-        }
-        [Fact]
-        public void TestNegotiationNoticeDeadline_EmptyStringAsData()
-        {
-            string JSONDataBad = "{}";
-            var arb = new ArbitrationCase();
-            arb.NSATracking = string.Empty;
-            Assert.Null(arb.NegotiationNoticeDeadline);
+
+            if (!string.IsNullOrEmpty(eobDate))
+            {
+                arb.EOBDate = DateTime.Parse(eobDate);
+            }
+
+            if (expectedException != null)
+            {
+                Assert.Throws(expectedException, () => arb.NSATracking = jsonData);
+                return;
+            }
+
+            arb.NSATracking = jsonData;
+
+            if (expectedDeadline == null)
+            {
+                Assert.Null(arb.NegotiationNoticeDeadline);
+            }
+            else
+            {
+                Assert.Equal(expectedDeadline, arb.NegotiationNoticeDeadline!.Value.ToString("yyyy-MM-dd"));
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace multiple negotiation notice deadline tests with a single theory using shared data
- cover valid, fallback, null, and exception scenarios through member data

## Testing
- dotnet test (fails: command not found: dotnet)


------
https://chatgpt.com/codex/tasks/task_e_68c8931221108326bbe1554e98845b02