### PR TITLE
Add Arbitration build/test job to validate stage

### DIFF
--- a/.ado/templates/tf-validate.yml
+++ b/.ado/templates/tf-validate.yml
@@ -4,9 +4,14 @@ parameters:
   - name: tfVersion
     type: string
     default: '1.7.5'
+  - name: dependsOn
+    type: string
+    default: ''
 
 jobs:
 - job: validate_${{ parameters.envName }}
+  ${{ if ne(parameters.dependsOn, '') }}:
+    dependsOn: ${{ parameters.dependsOn }}
   displayName: "Terraform fmt & validate (${{ parameters.envName }})"
   steps:
   - checkout: self

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,10 +21,32 @@ stages:
 - stage: Validate
   displayName: Validate & Lint
   jobs:
+  - job: build_arbitration
+    displayName: Build & Test Arbitration Solution
+    steps:
+    - checkout: self
+    - task: DotNetCoreCLI@2
+      displayName: Restore MPArbitration.sln
+      inputs:
+        command: 'restore'
+        projects: 'Arbitration/MPArbitration.sln'
+    - task: DotNetCoreCLI@2
+      displayName: Build MPArbitration.sln
+      inputs:
+        command: 'build'
+        projects: 'Arbitration/MPArbitration.sln'
+        arguments: '--configuration Release --no-restore'
+    - task: DotNetCoreCLI@2
+      displayName: Run Arbitration tests
+      inputs:
+        command: 'test'
+        projects: 'tests/TestArbitApi/Tests.csproj'
+        arguments: '--configuration Release --no-build --no-restore'
   - template: .ado/templates/tf-validate.yml
     parameters:
       envName: dev
       tfVersion: ${{ variables.TF_VERSION }}
+      dependsOn: build_arbitration
 
 - stage: Plan_All
   displayName: Terraform Plan (dev, stage, prod)


### PR DESCRIPTION
## Summary
- add a build-and-test job for Arbitration/MPArbitration.sln to the Validate stage
- allow the Terraform validate job template to depend on the build to enforce ordering

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68c8931434f483268029cedeef58d9f2