### PR TITLE
Update ASPNETCORE_URLS value in MPArbitration Dockerfile

### DIFF
--- a/Arbitration/MPArbitration/Dockerfile.linux
+++ b/Arbitration/MPArbitration/Dockerfile.linux
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
-ENV ASPNETCORE_URLS=http://+:80;
+ENV ASPNETCORE_URLS=http://+:80
 
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src


### PR DESCRIPTION
## Summary
- remove the trailing semicolon from ASPNETCORE_URLS so the container binds to port 80

## Testing
- not run (docker unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68c898627f5083269af3b481ad881ee3