### PR TITLE
Enable analyzers for MPArbitration

### DIFF
--- a/Arbitration/MPArbitration/MPArbitration.csproj
+++ b/Arbitration/MPArbitration/MPArbitration.csproj
@@ -8,9 +8,9 @@
     <SpaProxyServerUrl>https://localhost:44473</SpaProxyServerUrl>
     <SpaProxyLaunchCommand>npm start</SpaProxyLaunchCommand>
     <ImplicitUsings>enable</ImplicitUsings>
-    <RunAnalyzersDuringBuild>False</RunAnalyzersDuringBuild>
-    <RunAnalyzersDuringLiveAnalysis>False</RunAnalyzersDuringLiveAnalysis>
-    <EnableNETAnalyzers>False</EnableNETAnalyzers>
+    <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
+    <RunAnalyzersDuringLiveAnalysis>true</RunAnalyzersDuringLiveAnalysis>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <Configurations>Debug;Release;Stage</Configurations>
     <UserSecretsId>597763ab-a669-44af-a67c-c91cd32193f0</UserSecretsId>
 	<EnableSourceControlManagerQueries>true</EnableSourceControlManagerQueries>


### PR DESCRIPTION
## Summary
- enable .NET analyzers in the MPArbitration project so that static analysis runs during builds and live analysis

## Testing
- Attempted `dotnet build Arbitration/MPArbitration.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8985f37608326909274d1842ae9f9