### PR TITLE
Add Docker ignore rules for MPArbitration project

### DIFF
--- a/Arbitration/MPArbitration/.dockerignore
+++ b/Arbitration/MPArbitration/.dockerignore
@@ -1,0 +1,6 @@
+bin/
+obj/
+**/node_modules/
+.git
+*.ps1
+*.sh


### PR DESCRIPTION
## Summary
- add a Docker ignore file for the MPArbitration project
- exclude build outputs, node modules, git metadata, and shell scripts from Docker context

## Testing
- ⚠️ `dotnet build Arbitration/MPArbitration/MPArbitration.csproj` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8985c48c88326980a49c008e42ffe