### PR TITLE
Make AKS dns_prefix required and document usage

### DIFF
--- a/platform/infra/Azure/modules/aks/README.md
+++ b/platform/infra/Azure/modules/aks/README.md
@@ -1,0 +1,24 @@
+# AKS module
+
+Creates an Azure Kubernetes Service (AKS) cluster.
+
+## Usage
+
+```hcl
+module "aks" {
+  source = "../../Azure/modules/aks"
+
+  name                = "aks-example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  dns_prefix          = "aks-example"
+
+  node_count = 2
+  vm_size    = "Standard_DS2_v2"
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
+The `dns_prefix` input is required and sets the prefix that Azure uses when creating DNS entries for the cluster's API server endpoint.

--- a/platform/infra/Azure/modules/aks/main.tf
+++ b/platform/infra/Azure/modules/aks/main.tf
@@ -2,7 +2,7 @@ resource "azurerm_kubernetes_cluster" "this" {
   name                = var.name
   location            = var.location
   resource_group_name = var.resource_group_name
-  dns_prefix          = var.dns_prefix != "" ? var.dns_prefix : var.name
+  dns_prefix          = var.dns_prefix
 
   default_node_pool {
     name       = "default"

--- a/platform/infra/Azure/modules/aks/variables.tf
+++ b/platform/infra/Azure/modules/aks/variables.tf
@@ -12,7 +12,6 @@ variable "location" {
 
 variable "dns_prefix" {
   type    = string
-  default = ""
 }
 
 variable "node_count" {


### PR DESCRIPTION
## Summary
- require callers of the AKS module to provide a DNS prefix explicitly
- add module documentation that demonstrates setting the required `dns_prefix`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c89aa444848326a0d8cee138ad62e6