### PR TITLE
Build Angular assets during Docker publish

### DIFF
--- a/Arbitration/MPArbitration/Dockerfile.linux
+++ b/Arbitration/MPArbitration/Dockerfile.linux
@@ -17,11 +17,14 @@ COPY . .
 WORKDIR "/src/."
 
 ARG configuration=Release
+RUN npm ci --prefix ClientApp && npm run build --prefix ClientApp
 RUN dotnet build "MPArbitration.csproj" -c $configuration -o /app/build
 
 FROM build AS publish
 ARG configuration=Release
 RUN dotnet publish "MPArbitration.csproj" -c $configuration -o /app/publish /p:UseAppHost=false
+RUN mkdir -p /app/publish/ClientApp/dist \
+    && cp -r ClientApp/dist/. /app/publish/ClientApp/dist
 
 FROM base AS final
 WORKDIR /app


### PR DESCRIPTION
## Summary
- install ClientApp node dependencies and run the Angular production build during the Docker build stage
- copy the generated ClientApp/dist assets into the publish directory so they are available in the final image

## Testing
- `docker build -f Arbitration/MPArbitration/Dockerfile.linux -t mp-arbitration:test .` *(fails: `docker` not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c89b6e9a9c832682110a97472d9407