### PR TITLE
Add administrator credentials to MSSQL server module

### DIFF
--- a/platform/infra/Azure/modules/mssql-server/README.md
+++ b/platform/infra/Azure/modules/mssql-server/README.md
@@ -1,0 +1,32 @@
+# mssql-server module
+
+Provisions an Azure SQL (MSSQL) server instance.
+
+## Inputs
+
+- `name` (`string`, required) – Name of the SQL server resource.
+- `location` (`string`, required) – Azure region where the server will be deployed.
+- `resource_group_name` (`string`, required) – Resource group that hosts the server.
+- `administrator_login` (`string`, required) – Login name for the SQL administrator account.
+- `administrator_password` (`string`, required, sensitive) – Password for the SQL administrator account. Store this value securely (for example in Key Vault or a secret store) and pass it to Terraform as a sensitive variable.
+- `sku` (`string`, optional) – SKU for the SQL server. Defaults to `Standard`.
+
+### Example
+
+```hcl
+module "mssql_server" {
+  source = "../modules/mssql-server"
+
+  name                = "sql-prod-01"
+  location            = "eastus2"
+  resource_group_name = azurerm_resource_group.example.name
+
+  administrator_login    = "sqladminuser"
+  administrator_password = var.sql_admin_password
+}
+
+variable "sql_admin_password" {
+  type      = string
+  sensitive = true
+}
+```

--- a/platform/infra/Azure/modules/mssql-server/main.tf
+++ b/platform/infra/Azure/modules/mssql-server/main.tf
@@ -3,6 +3,6 @@ resource "azurerm_mssql_server" "this" {
   resource_group_name          = var.resource_group_name
   location                     = var.location
   version                      = "12.0"
-  # administrator_login          = var.admin_login
-  # administrator_login_password = var.admin_password
+  administrator_login          = var.administrator_login
+  administrator_login_password = var.administrator_password
 }

--- a/platform/infra/Azure/modules/mssql-server/variables.tf
+++ b/platform/infra/Azure/modules/mssql-server/variables.tf
@@ -1,5 +1,24 @@
-variable "name" {}
-variable "location" {}
-variable "resource_group_name" {}
-variable "sku" { default = "Standard" }
-variable "public_ip_id" {}
+variable "name" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "resource_group_name" {
+  type = string
+}
+
+variable "administrator_login" {
+  type = string
+}
+
+variable "administrator_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "sku" {
+  default = "Standard"
+}


### PR DESCRIPTION
## Summary
- declare string-typed module variables and add administrator credential inputs while removing the unused public IP variable
- configure the MSSQL server resource to use the administrator login and password variables
- document module inputs and provide an example showing how to supply the required credentials

## Testing
- terraform fmt platform/infra/Azure/modules/mssql-server *(fails: terraform binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c89de2de488326b3e719cf5907e3c6