### PR TITLE
Remove unused NSG variables

### DIFF
--- a/platform/infra/Azure/modules/network-security-group/variables.tf
+++ b/platform/infra/Azure/modules/network-security-group/variables.tf
@@ -1,5 +1,11 @@
-variable "name" {}
-variable "location" {}
-variable "resource_group_name" {}
-variable "sku" { default = "Standard" }
-variable "public_ip_id" {}
+variable "name" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "resource_group_name" {
+  type = string
+}


### PR DESCRIPTION
## Summary
- remove unused sku and public_ip_id inputs from the network security group module
- declare explicit string types for the remaining required variables

## Testing
- terraform init -backend=false *(fails: terraform binary is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c89de3bff48326b211eae5faa6ffdf