### PR TITLE
Define lb module variable types

### DIFF
--- a/platform/infra/Azure/modules/lb/variables.tf
+++ b/platform/infra/Azure/modules/lb/variables.tf
@@ -1,5 +1,25 @@
-variable "name" {}
-variable "location" {}
-variable "resource_group_name" {}
-variable "sku" { default = "Standard" }
-variable "public_ip_id" {}
+variable "name" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "resource_group_name" {
+  type = string
+}
+
+variable "sku" {
+  type    = string
+  default = "Standard"
+
+  validation {
+    condition     = contains(["Standard", "Basic"], var.sku)
+    error_message = "The sku must be either \"Standard\" or \"Basic\"."
+  }
+}
+
+variable "public_ip_id" {
+  type = string
+}


### PR DESCRIPTION
## Summary
- set explicit string types for the load balancer module inputs and add SKU validation

## Testing
- terraform init -backend=false *(fails: terraform not installed in environment)*
- terraform validate *(not run: terraform binary unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c89de482a083268c7652341a6c3c94