### PR TITLE
Require external SQL admin credentials for dev env

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ arbit-consolidated-infra-ado/
 | Service connections | Parameters in plan/apply templates | Rename to match your ADO service connections. |
 | Feature toggles | `platform/infra/envs/<env>/terraform.tfvars` | Toggle modules (Storage, SQL, AKS/ACR, Key Vault access). |
 | Backend coordinates | `platform/infra/envs/<env>/backend.tfvars` | Update RG/Storage/Container names per environment. |
-| SQL secrets (optional) | ADO variable groups | Pass via `extraVarFlags` (e.g., `-var "sql_admin_login=..."`). |
+| SQL admin credentials | ADO variable groups / Key Vault / secure `terraform.tfvars` | Required when `enable_sql = true`; provide before running plan/apply. |
 
 ### Manual runs and re-runs
 

--- a/platform/infra/envs/dev/terraform.tfvars
+++ b/platform/infra/envs/dev/terraform.tfvars
@@ -3,6 +3,9 @@ env_name     = "dev"
 location     = "eastus"
 
 # Secrets are injected at runtime via the pipeline / Key Vault.
+# Ensure `sql_admin_login` and `sql_admin_password` are supplied securely (for example,
+# via an untracked terraform.tfvars file, a variable group, or Key Vault) before
+# running `terraform plan` or `terraform apply`.
 
 tags = {
   project = "arbit"
@@ -101,9 +104,6 @@ sql_max_size_gb          = 75
 sql_min_capacity         = 0.5
 sql_max_capacity         = 4
 sql_public_network_access = true
-sql_admin_login          = ""
-sql_admin_password       = ""
-
 sql_firewall_rules = [
   {
     name             = "allow-all"

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -334,14 +334,12 @@ variable "sql_firewall_rules" {
 variable "sql_admin_login" {
   description = "Administrator login for the SQL server."
   type        = string
-  default     = ""
 }
 
 variable "sql_admin_password" {
   description = "Administrator password for the SQL server."
   type        = string
   sensitive   = true
-  default     = ""
 }
 
 # -------------------------


### PR DESCRIPTION
## Summary
- remove empty-string defaults for the dev SQL administrator variables
- drop placeholder credentials from the shared terraform.tfvars and document how to supply them securely
- update the README configuration table to highlight the requirement for providing SQL admin credentials before plan/apply

## Testing
- terraform fmt -check platform/infra/envs/dev *(fails: terraform not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c89de573708326b09712499675c21e