### PR TITLE
Remove redundant package-lock from MPArbitration root

### DIFF
--- a/Arbitration/MPArbitration/package-lock.json
+++ b/Arbitration/MPArbitration/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "MPArbitration",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## Summary
- delete the redundant package-lock.json from Arbitration/MPArbitration since dependencies are managed under ClientApp

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8b2a9466483269d2149a3c630bb2b