### PR TITLE
Pin Node.js version for MPArbitration build

### DIFF
--- a/Arbitration/MPArbitration/Dockerfile.linux
+++ b/Arbitration/MPArbitration/Dockerfile.linux
@@ -6,8 +6,14 @@ ENV ASPNETCORE_URLS=http://+:80
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 
+ARG NODE_VERSION=18.19.1
+
+# Install build tooling and the Node.js 18.19.1 LTS release for the Angular frontend build
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends build-essential nodejs npm \
+    && apt-get install -y --no-install-recommends build-essential ca-certificates curl xz-utils \
+    && curl -fsSLO "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" \
+    && tar -xJf "node-v${NODE_VERSION}-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
+    && rm "node-v${NODE_VERSION}-linux-x64.tar.xz" \
     && rm -rf /var/lib/apt/lists/*
 RUN npm --version
 


### PR DESCRIPTION
## Summary
- install the Node.js 18.19.1 LTS release in the MPArbitration Docker build stage
- document the pinned Node.js version directly in the Dockerfile comments

## Testing
- docker build -f Arbitration/MPArbitration/Dockerfile.linux Arbitration/MPArbitration -t mp-arbitration:test *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b2abbf688326bf70fbc94cabdd4a