### PR TITLE
Add ConfigurationManager dependency to MPArbitration

### DIFF
--- a/Arbitration/MPArbitration/MPArbitration.csproj
+++ b/Arbitration/MPArbitration/MPArbitration.csproj
@@ -51,6 +51,7 @@
     <PackageReference Include="ObjectComparator" Version="3.5.7" />
     <PackageReference Include="SendGrid" Version="9.29.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- add a dependency on System.Configuration.ConfigurationManager to MPArbitration so the API is available

## Testing
- dotnet restore Arbitration/MPArbitration/MPArbitration.csproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b4437fcc832699a7c1810c472a96