### PR TITLE
Adjust MPArbitration dependencies for .NET 6

### DIFF
--- a/Arbitration/MPArbitration/MPArbitration.csproj
+++ b/Arbitration/MPArbitration/MPArbitration.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="HtmlAgilityPack.NetCore" Version="1.5.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="6.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.6" />
@@ -42,7 +41,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="Microsoft.Identity.Web" Version="1.25.0" />
     <PackageReference Include="Microsoft.Identity.Web.UI" Version="1.25.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.6" />


### PR DESCRIPTION
## Summary
- remove the obsolete Microsoft.AspNetCore.Authentication package reference from the MPArbitration project
- downgrade Microsoft.Extensions.Caching.Memory to a .NET 6-compatible version

## Testing
- `dotnet restore Arbitration/MPArbitration.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b4412dec83269bf08b818ae54278