### PR TITLE
Add Arbitration client npm steps to pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,12 @@ stages:
       inputs:
         command: 'restore'
         projects: 'Arbitration/MPArbitration.sln'
+    - script: npm ci --prefix Arbitration/MPArbitration/ClientApp
+      displayName: Install Arbitration client dependencies
+    - script: npm test --prefix Arbitration/MPArbitration/ClientApp
+      displayName: Run Arbitration client tests
+    - script: npm run build-dev --prefix Arbitration/MPArbitration/ClientApp
+      displayName: Build Arbitration client (dev)
     - task: DotNetCoreCLI@2
       displayName: Build MPArbitration.sln
       inputs:


### PR DESCRIPTION
## Summary
- add npm install, test, and build steps for the MPArbitration client in the Validate stage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8b4b9bf10832691bc792daf844eff