### PR TITLE
Remove prebuild script from MPArbitration client

### DIFF
--- a/Arbitration/MPArbitration/ClientApp/package.json
+++ b/Arbitration/MPArbitration/ClientApp/package.json
@@ -7,7 +7,6 @@
     "start": "run-script-os",
     "start:windows": "ng serve --port 44473 --ssl --ssl-cert %APPDATA%\\ASP.NET\\https\\%npm_package_name%.pem --ssl-key %APPDATA%\\ASP.NET\\https\\%npm_package_name%.key",
     "start:default": "ng serve --port 44473 --ssl --ssl-cert $HOME/.aspnet/https/${npm_package_name}.pem --ssl-key $HOME/.aspnet/https/${npm_package_name}.key",
-    "prebuild": "npm --no-git-tag-version version patch",
     "build": "ng build",
     "build-stage": "ng build --prod=false --configuration stage",
     "build-dev": "ng build --prod=false --configuration dev",


### PR DESCRIPTION
## Summary
- remove the npm prebuild script that bumped the package version during builds
- note that version management should be handled by release tooling or CI variables instead

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8b4b8ef4c8326b957e9b932fca3cc