### PR TITLE
Specify types for lb rule module variables

### DIFF
--- a/platform/infra/Azure/modules/lb-rule/variables.tf
+++ b/platform/infra/Azure/modules/lb-rule/variables.tf
@@ -1,9 +1,36 @@
-variable "name" {}
-variable "resource_group_name" {}
-variable "loadbalancer_id" {}
-variable "protocol" { default = "Tcp" }
-variable "frontend_port" {}
-variable "backend_port" {}
-variable "frontend_ip_name" {}
-variable "backend_pool_id" {}
-variable "probe_id" {}
+variable "name" {
+  type = string
+}
+
+variable "resource_group_name" {
+  type = string
+}
+
+variable "loadbalancer_id" {
+  type = string
+}
+
+variable "protocol" {
+  type    = string
+  default = "Tcp"
+}
+
+variable "frontend_port" {
+  type = number
+}
+
+variable "backend_port" {
+  type = number
+}
+
+variable "frontend_ip_name" {
+  type = string
+}
+
+variable "backend_pool_id" {
+  type = string
+}
+
+variable "probe_id" {
+  type = string
+}


### PR DESCRIPTION
## Summary
- declare explicit types and default for the Azure load balancer rule module variables to improve validation

## Testing
- `terraform init -backend=false` *(fails: terraform binary is not available in the execution environment)*


------
https://chatgpt.com/codex/tasks/task_e_68c8b4b812c0832685608551046d06ee