### PR TITLE
Restore Linux VM configuration variables

### DIFF
--- a/platform/infra/Azure/modules/linux-virtual-machine/README.md
+++ b/platform/infra/Azure/modules/linux-virtual-machine/README.md
@@ -1,0 +1,27 @@
+# Linux virtual machine module
+
+This module provisions an Azure Linux virtual machine using an existing network interface. Provide the VM sizing, administrator credentials, and image reference details via input variables.
+
+## Example usage
+
+```hcl
+module "linux_vm" {
+  source = "../../modules/linux-virtual-machine"
+
+  name                = "example-vm"
+  location            = "eastus"
+  resource_group_name = azurerm_resource_group.example.name
+  nic_id              = azurerm_network_interface.example.id
+
+  size           = "Standard_B2s"
+  admin_username = "azureuser"
+
+  image_publisher = "Canonical"
+  image_offer     = "0001-com-ubuntu-server-jammy"
+  image_sku       = "22_04-lts"
+
+  ssh_key = file("~/.ssh/id_rsa.pub")
+}
+```
+
+The SSH key should be a public key string (for example, the contents of `~/.ssh/id_rsa.pub`).

--- a/platform/infra/Azure/modules/linux-virtual-machine/main.tf
+++ b/platform/infra/Azure/modules/linux-virtual-machine/main.tf
@@ -2,8 +2,8 @@ resource "azurerm_linux_virtual_machine" "this" {
   name                = var.name
   location            = var.location
   resource_group_name = var.resource_group_name
-  # size                = var.size
-  # admin_username      = var.admin_username
+  size                = var.size
+  admin_username      = var.admin_username
 
   network_interface_ids = [var.nic_id]
 
@@ -12,15 +12,15 @@ resource "azurerm_linux_virtual_machine" "this" {
     storage_account_type = "Standard_LRS"
   }
 
-  # source_image_reference {
-  #   publisher = var.image_publisher
-  #   offer     = var.image_offer
-  #   sku       = var.image_sku
-  #   version   = "latest"
-  # }
-  #
-  # admin_ssh_key {
-  #   username   = var.admin_username
-  #   public_key = var.ssh_key
-  # }
+  source_image_reference {
+    publisher = var.image_publisher
+    offer     = var.image_offer
+    sku       = var.image_sku
+    version   = "latest"
+  }
+
+  admin_ssh_key {
+    username   = var.admin_username
+    public_key = var.ssh_key
+  }
 }

--- a/platform/infra/Azure/modules/linux-virtual-machine/variables.tf
+++ b/platform/infra/Azure/modules/linux-virtual-machine/variables.tf
@@ -13,10 +13,34 @@ variable "resource_group_name" {
   type        = string
 }
 
-variable "sku" {
-  description = "SKU/size of the virtual machine."
+variable "size" {
+  description = "Azure compute size (SKU) to use for the virtual machine, e.g. Standard_DS1_v2."
   type        = string
-  default     = "Standard"
+}
+
+variable "admin_username" {
+  description = "Admin username provisioned on the Linux VM."
+  type        = string
+}
+
+variable "image_publisher" {
+  description = "Publisher of the image used to create the VM."
+  type        = string
+}
+
+variable "image_offer" {
+  description = "Offer of the image used to create the VM."
+  type        = string
+}
+
+variable "image_sku" {
+  description = "SKU of the image used to create the VM."
+  type        = string
+}
+
+variable "ssh_key" {
+  description = "SSH public key that will be added for the admin user."
+  type        = string
 }
 
 variable "nic_id" {


### PR DESCRIPTION
## Summary
- reintroduce Linux VM module variables for VM size, administrator, image reference, and SSH key
- wire the variables into the azurerm_linux_virtual_machine resource and document example usage

## Testing
- terraform fmt platform/infra/Azure/modules/linux-virtual-machine *(fails: terraform not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b662193c8326afedc68af337d59f