### PR TITLE
Stop ignoring Terraform lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ override.tf.json
 *_override.tf
 *_override.tf.json
 *.tfplan
-**/.terraform.lock.hcl
 
 # Editor directories
 .vscode/


### PR DESCRIPTION
## Summary
- remove the ignore rule for Terraform lock files so they can be version controlled

## Testing
- not run (Terraform CLI is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68c8b646546083269cdd488412ebba6c