### PR TITLE
Add tags support to network security group module

### DIFF
--- a/platform/infra/Azure/modules/network-security-group/README.md
+++ b/platform/infra/Azure/modules/network-security-group/README.md
@@ -1,0 +1,21 @@
+# Network security group module
+
+Creates an Azure Network Security Group (NSG).
+
+## Usage
+
+```hcl
+module "network_security_group" {
+  source = "../../Azure/modules/network-security-group"
+
+  name                = "nsg-example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
+The `tags` input is optional. When omitted, the NSG is created without custom tags.

--- a/platform/infra/Azure/modules/network-security-group/main.tf
+++ b/platform/infra/Azure/modules/network-security-group/main.tf
@@ -2,4 +2,5 @@ resource "azurerm_network_security_group" "this" {
   name                = var.name
   location            = var.location
   resource_group_name = var.resource_group_name
+  tags                = var.tags
 }

--- a/platform/infra/Azure/modules/network-security-group/variables.tf
+++ b/platform/infra/Azure/modules/network-security-group/variables.tf
@@ -9,3 +9,8 @@ variable "location" {
 variable "resource_group_name" {
   type = string
 }
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}


### PR DESCRIPTION
## Summary
- add an optional `tags` input to the network security group module and wire it into the NSG resource
- document example usage of the module including optional tags

## Testing
- terraform fmt platform/infra/Azure/modules/network-security-group *(fails: terraform not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b65fd6388326ada54b577049d39e