### PR TITLE
Update ClientApp gitignore to ignore node artifacts

### DIFF
--- a/Arbitration/MPArbitration/ClientApp/.gitignore
+++ b/Arbitration/MPArbitration/ClientApp/.gitignore
@@ -1,13 +1,13 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist
-/dist-server
-/tmp
-/out-tsc
+dist/
+dist-server/
+tmp/
+out-tsc/
 
 # dependencies
-/node_modules
+node_modules/
 
 # IDEs and editors
 /.idea


### PR DESCRIPTION
## Summary
- update the ClientApp .gitignore patterns to use trailing slashes for build and dependency folders

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/@ng-select%2fng-select)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b662c4d083268d69574230c91fef