### PR TITLE
Add tags input to managed disk module

### DIFF
--- a/platform/infra/Azure/modules/managed-disk/README.md
+++ b/platform/infra/Azure/modules/managed-disk/README.md
@@ -1,0 +1,30 @@
+# managed-disk module
+
+Provisions an Azure managed disk resource.
+
+## Inputs
+
+- `name` (`string`, required) – Name of the managed disk.
+- `location` (`string`, required) – Azure region where the managed disk will be deployed.
+- `resource_group_name` (`string`, required) – Resource group in which the managed disk will be created.
+- `disk_size_gb` (`number`, required) – Size of the managed disk in GB.
+- `storage_account_type` (`string`, optional, default `Standard_LRS`) – Specifies the storage redundancy (for example `Standard_LRS` or `Premium_LRS`).
+- `tags` (`map(string)`, optional, default `{}`) – Map of tags to apply to the managed disk.
+
+## Example
+
+```hcl
+module "managed_disk" {
+  source = "../modules/managed-disk"
+
+  name                = "vmdata01"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  disk_size_gb        = 128
+  storage_account_type = "Premium_LRS"
+
+  tags = {
+    Environment = "prod"
+  }
+}
+```

--- a/platform/infra/Azure/modules/managed-disk/main.tf
+++ b/platform/infra/Azure/modules/managed-disk/main.tf
@@ -5,4 +5,5 @@ resource "azurerm_managed_disk" "this" {
   storage_account_type = var.storage_account_type
   disk_size_gb         = var.disk_size_gb
   create_option        = "Empty"
+  tags                 = var.tags
 }

--- a/platform/infra/Azure/modules/managed-disk/variables.tf
+++ b/platform/infra/Azure/modules/managed-disk/variables.tf
@@ -23,3 +23,9 @@ variable "storage_account_type" {
   type        = string
   default     = "Standard_LRS"
 }
+
+variable "tags" {
+  description = "Tags to apply to the managed disk."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary
- add a tags variable to the managed disk module and propagate it to the resource
- document the optional tags map in the module README for discoverability

## Testing
- terraform fmt platform/infra/Azure/modules/managed-disk *(fails: terraform not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b660d4348326a21fda5d486f3098