### PR TITLE
Update Angular test command

### DIFF
--- a/Arbitration/MPArbitration/ClientApp/package.json
+++ b/Arbitration/MPArbitration/ClientApp/package.json
@@ -12,7 +12,7 @@
     "build-dev": "ng build --prod=false --configuration dev",
     "build:ssr": "ng run MPArbitration:server:dev",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test --watch=false --browsers=ChromeHeadless"
   },
   "private": true,
   "dependencies": {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,9 @@ stages:
         projects: 'Arbitration/MPArbitration.sln'
     - script: npm ci --prefix Arbitration/MPArbitration/ClientApp
       displayName: Install Arbitration client dependencies
-    - script: npm test --prefix Arbitration/MPArbitration/ClientApp
+    - script: |
+        cd Arbitration/MPArbitration/ClientApp
+        npm test
       displayName: Run Arbitration client tests
     - script: npm run build-dev --prefix Arbitration/MPArbitration/ClientApp
       displayName: Build Arbitration client (dev)


### PR DESCRIPTION
## Summary
- run the Angular test script in headless Chrome without watch mode
- invoke the test script directly in the Azure pipeline without extra CLI flags

## Testing
- npm test *(fails: ng not found because dependencies could not be installed; npm registry returns 403 when fetching @ng-select/ng-select)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b8279a208326b90dece2d74c3905