### PR TITLE
Configure CORS policy for MPExternalDisputeAPI

### DIFF
--- a/Arbitration/MPExternalDisputeAPI/Program.cs
+++ b/Arbitration/MPExternalDisputeAPI/Program.cs
@@ -13,6 +13,8 @@ internal class Program
 {
     private static void Main(string[] args)
     {
+        const string corsPolicyName = "CorsPolicy";
+
         var builder = WebApplication.CreateBuilder(args);
         // The following line enables Application Insights telemetry collection.
 //        builder.Services.AddApplicationInsightsTelemetry();
@@ -36,6 +38,16 @@ internal class Program
             o.BufferBody = true;
             o.ValueCountLimit = int.MaxValue;
         });
+        builder.Services.AddCors(options =>
+        {
+            options.AddPolicy(corsPolicyName, policy =>
+            {
+                policy.AllowAnyOrigin();
+                policy.AllowAnyMethod();
+                policy.AllowAnyHeader();
+            });
+        });
+
         builder.Services.AddEndpointsApiExplorer();
         builder.Services.AddSwaggerGen();
         builder.Services.AddSwaggerGen(opt =>
@@ -146,7 +158,7 @@ internal class Program
             app.UseHsts();
         }
         app.MapSwagger().RequireAuthorization();
-        app.UseCors();
+        app.UseCors(corsPolicyName);
         app.UseHttpsRedirection();
         app.UseStaticFiles();
         app.UseRouting();


### PR DESCRIPTION
## Summary
- add a named CORS policy to MPExternalDisputeAPI so all origins, methods, and headers are permitted
- update the middleware pipeline to use the configured policy

## Testing
- dotnet build (fails: `dotnet` is not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c8b8a206288326bbfa4c1964e17e00