### PR TITLE
Add global.json to pin .NET SDK version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
## Summary
- add a global.json at the repository root to pin the .NET SDK to 6.0.100
- configure rollForward to use the latest feature release when necessary

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8b86acd348326885efe43e9b520ef