### PR TITLE
Add Azure private endpoint module and private access toggles

### DIFF
--- a/platform/infra/Azure/modules/key-vault/main.tf
+++ b/platform/infra/Azure/modules/key-vault/main.tf
@@ -1,4 +1,32 @@
 data "azurerm_client_config" "current" {}
+
+locals {
+  network_acls_input = var.network_acls != null ? var.network_acls : {}
+
+  private_endpoint_subnet_ids = distinct(compact([
+    for endpoint in var.private_endpoints : try(endpoint.subnet_id, null)
+    if try(trimspace(endpoint.subnet_id), "") != ""
+  ]))
+
+  network_acls_effective = {
+    bypass                     = try(local.network_acls_input.bypass, null)
+    default_action             = try(local.network_acls_input.default_action, null)
+    ip_rules                   = try(local.network_acls_input.ip_rules, [])
+    virtual_network_subnet_ids = distinct(compact(concat(
+      try(local.network_acls_input.virtual_network_subnet_ids, []),
+      local.private_endpoint_subnet_ids,
+    )))
+  }
+
+  should_define_network_acls = (
+    var.network_acls != null ||
+    length(local.network_acls_effective.virtual_network_subnet_ids) > 0 ||
+    length(local.network_acls_effective.ip_rules) > 0 ||
+    local.network_acls_effective.bypass != null ||
+    local.network_acls_effective.default_action != null
+  )
+}
+
 resource "azurerm_key_vault" "kv" {
   name                          = var.name
   resource_group_name           = var.resource_group_name
@@ -9,4 +37,15 @@ resource "azurerm_key_vault" "kv" {
   soft_delete_retention_days    = 90
   public_network_access_enabled = var.public_network_access_enabled
   tags                          = var.tags
+
+  dynamic "network_acls" {
+    for_each = local.should_define_network_acls ? [local.network_acls_effective] : []
+
+    content {
+      bypass                     = network_acls.value.bypass
+      default_action             = network_acls.value.default_action
+      ip_rules                   = network_acls.value.ip_rules
+      virtual_network_subnet_ids = network_acls.value.virtual_network_subnet_ids
+    }
+  }
 }

--- a/platform/infra/Azure/modules/key-vault/variables.tf
+++ b/platform/infra/Azure/modules/key-vault/variables.tf
@@ -10,3 +10,23 @@ variable "public_network_access_enabled" {
   type    = bool
   default = true
 }
+
+variable "network_acls" {
+  description = "Optional network ACL configuration applied to the Key Vault."
+  type = object({
+    bypass                     = optional(string)
+    default_action             = optional(string)
+    ip_rules                   = optional(list(string))
+    virtual_network_subnet_ids = optional(list(string))
+  })
+  default = null
+}
+
+variable "private_endpoints" {
+  description = "Private endpoint definitions associated with the Key Vault for network ACL augmentation."
+  type = list(object({
+    id        = optional(string)
+    subnet_id = optional(string)
+  }))
+  default = []
+}

--- a/platform/infra/Azure/modules/private-endpoint/main.tf
+++ b/platform/infra/Azure/modules/private-endpoint/main.tf
@@ -1,0 +1,24 @@
+resource "azurerm_private_endpoint" "this" {
+  name                = var.name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  subnet_id           = var.subnet_id
+  tags                = var.tags
+
+  private_service_connection {
+    name                           = var.private_service_connection.name
+    private_connection_resource_id = var.private_service_connection.private_connection_resource_id
+    subresource_names              = var.private_service_connection.subresource_names
+    is_manual_connection           = var.private_service_connection.is_manual_connection
+    request_message                = var.private_service_connection.request_message
+  }
+
+  dynamic "private_dns_zone_group" {
+    for_each = var.private_dns_zone_groups
+
+    content {
+      name                 = private_dns_zone_group.value.name
+      private_dns_zone_ids = private_dns_zone_group.value.private_dns_zone_ids
+    }
+  }
+}

--- a/platform/infra/Azure/modules/private-endpoint/outputs.tf
+++ b/platform/infra/Azure/modules/private-endpoint/outputs.tf
@@ -1,0 +1,19 @@
+output "id" {
+  description = "Resource ID of the private endpoint."
+  value       = azurerm_private_endpoint.this.id
+}
+
+output "name" {
+  description = "Name of the private endpoint resource."
+  value       = azurerm_private_endpoint.this.name
+}
+
+output "network_interface_ids" {
+  description = "Identifiers of the network interfaces created for the private endpoint."
+  value       = azurerm_private_endpoint.this.network_interface_ids
+}
+
+output "subnet_id" {
+  description = "Subnet ID supplied to the private endpoint."
+  value       = var.subnet_id
+}

--- a/platform/infra/Azure/modules/private-endpoint/variables.tf
+++ b/platform/infra/Azure/modules/private-endpoint/variables.tf
@@ -1,0 +1,45 @@
+variable "name" {
+  description = "Name of the private endpoint resource."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Resource group where the private endpoint is created."
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region for the private endpoint."
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "Subnet resource ID hosting the private endpoint network interface."
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags applied to the private endpoint resource."
+  type        = map(string)
+  default     = {}
+}
+
+variable "private_service_connection" {
+  description = "Configuration for the private service connection bound to the endpoint."
+  type = object({
+    name                           = string
+    private_connection_resource_id = string
+    subresource_names              = optional(list(string), [])
+    is_manual_connection           = optional(bool, false)
+    request_message                = optional(string, null)
+  })
+}
+
+variable "private_dns_zone_groups" {
+  description = "Optional private DNS zone group associations for the endpoint."
+  type = list(object({
+    name                 = string
+    private_dns_zone_ids = list(string)
+  }))
+  default = []
+}

--- a/platform/infra/Azure/modules/storage-account/main.tf
+++ b/platform/infra/Azure/modules/storage-account/main.tf
@@ -1,3 +1,36 @@
+locals {
+  network_rules_input = var.network_rules != null ? var.network_rules : {}
+
+  private_endpoint_resource_ids = compact([
+    for endpoint in var.private_endpoints : try(trimspace(endpoint.id), "")
+    if try(trimspace(endpoint.id), "") != ""
+  ])
+
+  private_endpoint_subnet_ids = distinct(compact([
+    for endpoint in var.private_endpoints : try(endpoint.subnet_id, null)
+    if try(trimspace(endpoint.subnet_id), "") != ""
+  ]))
+
+  network_rules_effective = {
+    bypass                     = try(local.network_rules_input.bypass, [])
+    default_action             = try(local.network_rules_input.default_action, null)
+    ip_rules                   = try(local.network_rules_input.ip_rules, [])
+    virtual_network_subnet_ids = distinct(concat(
+      try(local.network_rules_input.virtual_network_subnet_ids, []),
+      local.private_endpoint_subnet_ids,
+    ))
+  }
+
+  should_define_network_rules = (
+    var.network_rules != null ||
+    length(local.network_rules_effective.bypass) > 0 ||
+    local.network_rules_effective.default_action != null ||
+    length(local.network_rules_effective.ip_rules) > 0 ||
+    length(local.network_rules_effective.virtual_network_subnet_ids) > 0 ||
+    length(local.private_endpoint_resource_ids) > 0
+  )
+}
+
 resource "azurerm_storage_account" "sa" {
   name                     = var.name
   resource_group_name      = var.resource_group_name
@@ -10,4 +43,23 @@ resource "azurerm_storage_account" "sa" {
   is_hns_enabled           = var.enable_hns
   min_tls_version          = var.min_tls_version
   tags                     = var.tags
+
+  dynamic "network_rules" {
+    for_each = local.should_define_network_rules ? [local.network_rules_effective] : []
+
+    content {
+      bypass                     = network_rules.value.bypass
+      default_action             = network_rules.value.default_action
+      ip_rules                   = network_rules.value.ip_rules
+      virtual_network_subnet_ids = network_rules.value.virtual_network_subnet_ids
+
+      dynamic "private_link_access" {
+        for_each = local.private_endpoint_resource_ids
+
+        content {
+          endpoint_resource_id = private_link_access.value
+        }
+      }
+    }
+  }
 }

--- a/platform/infra/Azure/modules/storage-account/variables.tf
+++ b/platform/infra/Azure/modules/storage-account/variables.tf
@@ -30,3 +30,23 @@ variable "tags" {
   type    = map(string)
   default = {}
 }
+
+variable "network_rules" {
+  description = "Optional network rules applied to the storage account."
+  type = object({
+    bypass                     = optional(list(string))
+    default_action             = optional(string)
+    ip_rules                   = optional(list(string))
+    virtual_network_subnet_ids = optional(list(string))
+  })
+  default = null
+}
+
+variable "private_endpoints" {
+  description = "Private endpoint definitions associated with the storage account for network rule augmentation."
+  type = list(object({
+    id        = optional(string)
+    subnet_id = optional(string)
+  }))
+  default = []
+}

--- a/platform/infra/envs/dev/main.tf
+++ b/platform/infra/envs/dev/main.tf
@@ -20,6 +20,8 @@ locals {
   storage_data_name    = lower(replace("st${var.project_name}${var.env_name}data", "-", ""))
   sql_server_name      = "sql-${var.project_name}-${var.env_name}"
   aad_app_display      = "aad-${var.project_name}-${var.env_name}"
+  kv_private_endpoint_name      = "pep-${var.project_name}-${var.env_name}-kv"
+  storage_private_endpoint_name = "pep-${var.project_name}-${var.env_name}-st"
 }
 
 module "resource_group" {
@@ -38,6 +40,22 @@ module "network" {
   dns_servers         = var.vnet_dns_servers
   subnets             = var.subnets
   tags                = var.tags
+}
+
+locals {
+  kv_private_endpoint_subnet_id = var.enable_kv_private_endpoint && var.kv_private_endpoint_subnet_key != null && var.kv_private_endpoint_subnet_key != "" ? lookup(module.network.subnet_ids, var.kv_private_endpoint_subnet_key, null) : null
+  kv_private_endpoints = local.kv_private_endpoint_subnet_id != null ? [
+    {
+      subnet_id = local.kv_private_endpoint_subnet_id
+    }
+  ] : []
+
+  storage_private_endpoint_subnet_id = var.enable_storage_private_endpoint && var.storage_private_endpoint_subnet_key != null && var.storage_private_endpoint_subnet_key != "" ? lookup(module.network.subnet_ids, var.storage_private_endpoint_subnet_key, null) : null
+  storage_private_endpoints = local.storage_private_endpoint_subnet_id != null ? [
+    {
+      subnet_id = local.storage_private_endpoint_subnet_id
+    }
+  ] : []
 }
 
 module "acr" {
@@ -169,7 +187,55 @@ module "kv" {
   resource_group_name           = module.resource_group.name
   location                      = var.location
   public_network_access_enabled = var.kv_public_network_access
+  network_acls                  = var.kv_network_acls
+  private_endpoints             = local.kv_private_endpoints
   tags                          = var.tags
+}
+
+module "kv_private_endpoint" {
+  count = var.enable_kv_private_endpoint && local.kv_private_endpoint_subnet_id != null && coalesce(var.kv_private_endpoint_resource_id, module.kv.id) != null ? 1 : 0
+  source              = "../../Azure/modules/private-endpoint"
+  name                = local.kv_private_endpoint_name
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  subnet_id           = local.kv_private_endpoint_subnet_id
+  tags                = var.tags
+
+  private_service_connection = {
+    name                           = "kv-${var.project_name}-${var.env_name}"
+    private_connection_resource_id = coalesce(var.kv_private_endpoint_resource_id, module.kv.id)
+    subresource_names              = ["vault"]
+  }
+
+  private_dns_zone_groups = length(var.kv_private_dns_zone_ids) > 0 ? [
+    {
+      name                 = "default"
+      private_dns_zone_ids = var.kv_private_dns_zone_ids
+    }
+  ] : []
+}
+
+module "storage_private_endpoint" {
+  count = var.enable_storage_private_endpoint && local.storage_private_endpoint_subnet_id != null && var.storage_account_private_connection_resource_id != null ? 1 : 0
+  source              = "../../Azure/modules/private-endpoint"
+  name                = local.storage_private_endpoint_name
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  subnet_id           = local.storage_private_endpoint_subnet_id
+  tags                = var.tags
+
+  private_service_connection = {
+    name                           = "st-${var.project_name}-${var.env_name}"
+    private_connection_resource_id = var.storage_account_private_connection_resource_id
+    subresource_names              = var.storage_private_endpoint_subresource_names
+  }
+
+  private_dns_zone_groups = length(var.storage_private_dns_zone_ids) > 0 ? [
+    {
+      name                 = "default"
+      private_dns_zone_ids = var.storage_private_dns_zone_ids
+    }
+  ] : []
 }
 
 module "dns_zone" {

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -52,6 +52,82 @@ variable "kv_public_network_access" {
   default     = true
 }
 
+variable "kv_network_acls" {
+  description = "Network ACL configuration applied to the Key Vault."
+  type = object({
+    bypass                     = optional(string)
+    default_action             = optional(string)
+    ip_rules                   = optional(list(string))
+    virtual_network_subnet_ids = optional(list(string))
+  })
+  default = null
+}
+
+variable "enable_kv_private_endpoint" {
+  description = "Toggle creation of a private endpoint for the Key Vault."
+  type        = bool
+  default     = false
+}
+
+variable "kv_private_endpoint_subnet_key" {
+  description = "Key of the subnet used when creating the Key Vault private endpoint."
+  type        = string
+  default     = null
+}
+
+variable "kv_private_dns_zone_ids" {
+  description = "Private DNS zone IDs linked to the Key Vault private endpoint."
+  type        = list(string)
+  default     = []
+}
+
+variable "kv_private_endpoint_resource_id" {
+  description = "Optional override for the Key Vault resource ID used by the private endpoint module."
+  type        = string
+  default     = null
+}
+
+variable "storage_network_rules" {
+  description = "Network rules applied to the storage account resource."
+  type = object({
+    bypass                     = optional(list(string))
+    default_action             = optional(string)
+    ip_rules                   = optional(list(string))
+    virtual_network_subnet_ids = optional(list(string))
+  })
+  default = null
+}
+
+variable "enable_storage_private_endpoint" {
+  description = "Toggle creation of a private endpoint for the storage account."
+  type        = bool
+  default     = false
+}
+
+variable "storage_private_endpoint_subnet_key" {
+  description = "Key of the subnet used when creating the storage account private endpoint."
+  type        = string
+  default     = null
+}
+
+variable "storage_private_dns_zone_ids" {
+  description = "Private DNS zone IDs linked to the storage account private endpoint."
+  type        = list(string)
+  default     = []
+}
+
+variable "storage_private_endpoint_subresource_names" {
+  description = "Subresource names exposed through the storage account private endpoint."
+  type        = list(string)
+  default     = ["blob"]
+}
+
+variable "storage_account_private_connection_resource_id" {
+  description = "Resource ID used by the storage account private endpoint connection."
+  type        = string
+  default     = null
+}
+
 # -------------------------
 # Networking
 # -------------------------

--- a/platform/infra/envs/prod/main.tf
+++ b/platform/infra/envs/prod/main.tf
@@ -22,6 +22,8 @@ locals {
 
   sql_server_name   = "sql-${var.project_name}-${var.env_name}"
   sql_database_name = var.sql_database_name != "" ? var.sql_database_name : "${var.project_name}-${var.env_name}"
+  kv_private_endpoint_name      = "pep-${var.project_name}-${var.env_name}-kv"
+  storage_private_endpoint_name = "pep-${var.project_name}-${var.env_name}-st"
 }
 
 # -------------------------
@@ -43,6 +45,57 @@ module "network" {
   dns_servers         = var.vnet_dns_servers
   subnets             = var.subnets
   tags                = var.tags
+}
+
+locals {
+  kv_private_endpoint_subnet_id = var.enable_kv_private_endpoint && var.kv_private_endpoint_subnet_key != null && var.kv_private_endpoint_subnet_key != "" ? lookup(module.network.subnet_ids, var.kv_private_endpoint_subnet_key, null) : null
+  storage_private_endpoint_subnet_id = var.enable_storage_private_endpoint && var.storage_private_endpoint_subnet_key != null && var.storage_private_endpoint_subnet_key != "" ? lookup(module.network.subnet_ids, var.storage_private_endpoint_subnet_key, null) : null
+}
+
+module "kv_private_endpoint" {
+  count = var.enable_kv_private_endpoint && local.kv_private_endpoint_subnet_id != null && var.kv_private_endpoint_resource_id != null ? 1 : 0
+  source              = "../../Azure/modules/private-endpoint"
+  name                = local.kv_private_endpoint_name
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  subnet_id           = local.kv_private_endpoint_subnet_id
+  tags                = var.tags
+
+  private_service_connection = {
+    name                           = "kv-${var.project_name}-${var.env_name}"
+    private_connection_resource_id = var.kv_private_endpoint_resource_id
+    subresource_names              = ["vault"]
+  }
+
+  private_dns_zone_groups = length(var.kv_private_dns_zone_ids) > 0 ? [
+    {
+      name                 = "default"
+      private_dns_zone_ids = var.kv_private_dns_zone_ids
+    }
+  ] : []
+}
+
+module "storage_private_endpoint" {
+  count = var.enable_storage_private_endpoint && local.storage_private_endpoint_subnet_id != null && var.storage_account_private_connection_resource_id != null ? 1 : 0
+  source              = "../../Azure/modules/private-endpoint"
+  name                = local.storage_private_endpoint_name
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  subnet_id           = local.storage_private_endpoint_subnet_id
+  tags                = var.tags
+
+  private_service_connection = {
+    name                           = "st-${var.project_name}-${var.env_name}"
+    private_connection_resource_id = var.storage_account_private_connection_resource_id
+    subresource_names              = var.storage_private_endpoint_subresource_names
+  }
+
+  private_dns_zone_groups = length(var.storage_private_dns_zone_ids) > 0 ? [
+    {
+      name                 = "default"
+      private_dns_zone_ids = var.storage_private_dns_zone_ids
+    }
+  ] : []
 }
 
 module "app_service" {

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -52,6 +52,82 @@ variable "kv_public_network_access" {
   default     = true
 }
 
+variable "kv_network_acls" {
+  description = "Network ACL configuration applied to the Key Vault."
+  type = object({
+    bypass                     = optional(string)
+    default_action             = optional(string)
+    ip_rules                   = optional(list(string))
+    virtual_network_subnet_ids = optional(list(string))
+  })
+  default = null
+}
+
+variable "enable_kv_private_endpoint" {
+  description = "Toggle creation of a private endpoint for the Key Vault."
+  type        = bool
+  default     = false
+}
+
+variable "kv_private_endpoint_subnet_key" {
+  description = "Key of the subnet used when creating the Key Vault private endpoint."
+  type        = string
+  default     = null
+}
+
+variable "kv_private_dns_zone_ids" {
+  description = "Private DNS zone IDs linked to the Key Vault private endpoint."
+  type        = list(string)
+  default     = []
+}
+
+variable "kv_private_endpoint_resource_id" {
+  description = "Optional override for the Key Vault resource ID used by the private endpoint module."
+  type        = string
+  default     = null
+}
+
+variable "storage_network_rules" {
+  description = "Network rules applied to the storage account resource."
+  type = object({
+    bypass                     = optional(list(string))
+    default_action             = optional(string)
+    ip_rules                   = optional(list(string))
+    virtual_network_subnet_ids = optional(list(string))
+  })
+  default = null
+}
+
+variable "enable_storage_private_endpoint" {
+  description = "Toggle creation of a private endpoint for the storage account."
+  type        = bool
+  default     = false
+}
+
+variable "storage_private_endpoint_subnet_key" {
+  description = "Key of the subnet used when creating the storage account private endpoint."
+  type        = string
+  default     = null
+}
+
+variable "storage_private_dns_zone_ids" {
+  description = "Private DNS zone IDs linked to the storage account private endpoint."
+  type        = list(string)
+  default     = []
+}
+
+variable "storage_private_endpoint_subresource_names" {
+  description = "Subresource names exposed through the storage account private endpoint."
+  type        = list(string)
+  default     = ["blob"]
+}
+
+variable "storage_account_private_connection_resource_id" {
+  description = "Resource ID used by the storage account private endpoint connection."
+  type        = string
+  default     = null
+}
+
 # -------------------------
 # Networking
 # -------------------------

--- a/platform/infra/envs/stage/main.tf
+++ b/platform/infra/envs/stage/main.tf
@@ -22,6 +22,8 @@ locals {
 
   sql_server_name   = "sql-${var.project_name}-${var.env_name}"
   sql_database_name = var.sql_database_name != "" ? var.sql_database_name : "${var.project_name}-${var.env_name}"
+  kv_private_endpoint_name      = "pep-${var.project_name}-${var.env_name}-kv"
+  storage_private_endpoint_name = "pep-${var.project_name}-${var.env_name}-st"
 }
 
 # -------------------------
@@ -45,6 +47,57 @@ module "network" {
   tags                = var.tags
   a_records           = var.dns_a_records
   cname_records       = var.dns_cname_records
+}
+
+locals {
+  kv_private_endpoint_subnet_id = var.enable_kv_private_endpoint && var.kv_private_endpoint_subnet_key != null && var.kv_private_endpoint_subnet_key != "" ? lookup(module.network.subnet_ids, var.kv_private_endpoint_subnet_key, null) : null
+  storage_private_endpoint_subnet_id = var.enable_storage_private_endpoint && var.storage_private_endpoint_subnet_key != null && var.storage_private_endpoint_subnet_key != "" ? lookup(module.network.subnet_ids, var.storage_private_endpoint_subnet_key, null) : null
+}
+
+module "kv_private_endpoint" {
+  count = var.enable_kv_private_endpoint && local.kv_private_endpoint_subnet_id != null && var.kv_private_endpoint_resource_id != null ? 1 : 0
+  source              = "../../Azure/modules/private-endpoint"
+  name                = local.kv_private_endpoint_name
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  subnet_id           = local.kv_private_endpoint_subnet_id
+  tags                = var.tags
+
+  private_service_connection = {
+    name                           = "kv-${var.project_name}-${var.env_name}"
+    private_connection_resource_id = var.kv_private_endpoint_resource_id
+    subresource_names              = ["vault"]
+  }
+
+  private_dns_zone_groups = length(var.kv_private_dns_zone_ids) > 0 ? [
+    {
+      name                 = "default"
+      private_dns_zone_ids = var.kv_private_dns_zone_ids
+    }
+  ] : []
+}
+
+module "storage_private_endpoint" {
+  count = var.enable_storage_private_endpoint && local.storage_private_endpoint_subnet_id != null && var.storage_account_private_connection_resource_id != null ? 1 : 0
+  source              = "../../Azure/modules/private-endpoint"
+  name                = local.storage_private_endpoint_name
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  subnet_id           = local.storage_private_endpoint_subnet_id
+  tags                = var.tags
+
+  private_service_connection = {
+    name                           = "st-${var.project_name}-${var.env_name}"
+    private_connection_resource_id = var.storage_account_private_connection_resource_id
+    subresource_names              = var.storage_private_endpoint_subresource_names
+  }
+
+  private_dns_zone_groups = length(var.storage_private_dns_zone_ids) > 0 ? [
+    {
+      name                 = "default"
+      private_dns_zone_ids = var.storage_private_dns_zone_ids
+    }
+  ] : []
 }
 
 module "app_service" {

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -52,6 +52,82 @@ variable "kv_public_network_access" {
   default     = true
 }
 
+variable "kv_network_acls" {
+  description = "Network ACL configuration applied to the Key Vault."
+  type = object({
+    bypass                     = optional(string)
+    default_action             = optional(string)
+    ip_rules                   = optional(list(string))
+    virtual_network_subnet_ids = optional(list(string))
+  })
+  default = null
+}
+
+variable "enable_kv_private_endpoint" {
+  description = "Toggle creation of a private endpoint for the Key Vault."
+  type        = bool
+  default     = false
+}
+
+variable "kv_private_endpoint_subnet_key" {
+  description = "Key of the subnet used when creating the Key Vault private endpoint."
+  type        = string
+  default     = null
+}
+
+variable "kv_private_dns_zone_ids" {
+  description = "Private DNS zone IDs linked to the Key Vault private endpoint."
+  type        = list(string)
+  default     = []
+}
+
+variable "kv_private_endpoint_resource_id" {
+  description = "Optional override for the Key Vault resource ID used by the private endpoint module."
+  type        = string
+  default     = null
+}
+
+variable "storage_network_rules" {
+  description = "Network rules applied to the storage account resource."
+  type = object({
+    bypass                     = optional(list(string))
+    default_action             = optional(string)
+    ip_rules                   = optional(list(string))
+    virtual_network_subnet_ids = optional(list(string))
+  })
+  default = null
+}
+
+variable "enable_storage_private_endpoint" {
+  description = "Toggle creation of a private endpoint for the storage account."
+  type        = bool
+  default     = false
+}
+
+variable "storage_private_endpoint_subnet_key" {
+  description = "Key of the subnet used when creating the storage account private endpoint."
+  type        = string
+  default     = null
+}
+
+variable "storage_private_dns_zone_ids" {
+  description = "Private DNS zone IDs linked to the storage account private endpoint."
+  type        = list(string)
+  default     = []
+}
+
+variable "storage_private_endpoint_subresource_names" {
+  description = "Subresource names exposed through the storage account private endpoint."
+  type        = list(string)
+  default     = ["blob"]
+}
+
+variable "storage_account_private_connection_resource_id" {
+  description = "Resource ID used by the storage account private endpoint connection."
+  type        = string
+  default     = null
+}
+
 # -------------------------
 # Networking
 # -------------------------


### PR DESCRIPTION
## Summary
- add a reusable private-endpoint module that provisions the endpoint and optional private DNS zone groups
- extend the Key Vault and storage account modules to accept network ACL definitions and optional private endpoint metadata
- expose private endpoint toggles and inputs in the dev/stage/prod environment configurations and create endpoints when enabled

## Testing
- `terraform fmt -recursive` *(fails: terraform not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b6df9888832693084e1daf088361