### PR TITLE
Run MPArbitration as non-root user

### DIFF
--- a/Arbitration/MPArbitration/Dockerfile.linux
+++ b/Arbitration/MPArbitration/Dockerfile.linux
@@ -35,4 +35,7 @@ RUN mkdir -p /app/publish/ClientApp/dist \
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+RUN useradd -m appuser \
+    && chown -R appuser /app
+USER appuser
 ENTRYPOINT ["dotnet", "MPArbitration.dll"]


### PR DESCRIPTION
## Summary
- create a dedicated non-root user in the MPArbitration Docker image
- switch the final stage to run as the new unprivileged user

## Testing
- not run (dotnet runtime is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c8be879ffc832698092e1a4ac8f908