### PR TITLE
Refactor NSA request script secret handling

### DIFF
--- a/docs/Arbitration-SendNSARequests.md
+++ b/docs/Arbitration-SendNSARequests.md
@@ -1,0 +1,35 @@
+# Arbitration NSA Request Script — Secret Configuration
+
+`scripts/Arbitration-SendNSARequests.ps1` retrieves a client secret at runtime so that nothing sensitive is stored in the repository. The script supports **environment variables** and **Azure Key Vault**; configure at least one option before running `SendNSARequests`.
+
+## Option 1 — Environment variable
+
+Set an environment variable that contains the client secret for the automation identity:
+
+- `ARBITRATION_CLIENT_SECRET`
+
+For multi-tenant scenarios you can provide tenant-specific overrides. Remove punctuation from the Azure AD tenant ID, convert it to uppercase, and append it to the base name with a double underscore:
+
+- `ARBITRATION_CLIENT_SECRET__2E09F3A30520461F8474052A8ED7814A`
+
+The script searches the Process, User, and Machine scopes and uses the first value it finds. This allows you to define the secret for all users on a jump box (Machine scope) or just the active shell session (Process scope).
+
+## Option 2 — Azure Key Vault
+
+If an environment variable is not set, the script attempts to resolve the secret from Azure Key Vault using the `Az.KeyVault` module. Set the following environment variables so the script knows which vault and secret to query:
+
+- `ARBITRATION_CLIENT_SECRET_VAULT_NAME`
+- `ARBITRATION_CLIENT_SECRET_SECRET_NAME`
+
+Tenant-specific overrides follow the same naming pattern as above:
+
+- `ARBITRATION_CLIENT_SECRET_VAULT_NAME__2E09F3A30520461F8474052A8ED7814A`
+- `ARBITRATION_CLIENT_SECRET_SECRET_NAME__2E09F3A30520461F8474052A8ED7814A`
+
+Ensure the PowerShell session is authenticated (for example with `Connect-AzAccount`) and that the identity has **Key Vault Secrets User** rights on the vault. The script raises an error if the secret cannot be retrieved from Key Vault.
+
+## Usage reminders
+
+- Configure either an environment variable or the Key Vault settings **per tenant** before running the script.
+- Keep the secret value out of version control—store it only in secure hosts or Azure Key Vault.
+- Run PowerShell with `-Verbose` to see which source (environment variable or Key Vault) supplied the client secret when troubleshooting.

--- a/scripts/Arbitration-SendNSARequests.ps1
+++ b/scripts/Arbitration-SendNSARequests.ps1
@@ -15,7 +15,7 @@ Param (
 
 Function GetNSAClaims {
 Param (
-[Parameter (Mandatory=$true)][string]$Token, 
+[Parameter (Mandatory=$true)][string]$Token,
 [Parameter (Mandatory=$true)][string]$TenantId
 )
 
@@ -35,38 +35,98 @@ Param (
     }
 }
 
+Function Get-FirstEnvironmentVariableValue {
+Param (
+[Parameter (Mandatory=$true)][string[]]$Names
+)
+    foreach ($name in $Names) {
+        foreach ($scope in @('Process', 'User', 'Machine')) {
+            $value = [System.Environment]::GetEnvironmentVariable($name, $scope)
+            if (-not [string]::IsNullOrWhiteSpace($value)) {
+                Write-Verbose "Using client secret value from environment variable '$name'."
+                return $value
+            }
+        }
+    }
 
+    return $null
+}
 
+Function Get-ClientSecret {
+Param (
+[Parameter (Mandatory=$true)][string]$TenantId
+)
+    $normalizedTenantId = ($TenantId -replace '[^a-zA-Z0-9]', '').ToUpper()
 
+    $environmentVariableCandidates = @()
+    if (-not [string]::IsNullOrWhiteSpace($normalizedTenantId)) {
+        $environmentVariableCandidates += "ARBITRATION_CLIENT_SECRET__${normalizedTenantId}"
+    }
+    $environmentVariableCandidates += 'ARBITRATION_CLIENT_SECRET'
 
+    $secret = Get-FirstEnvironmentVariableValue -Names $environmentVariableCandidates
+    if (-not [string]::IsNullOrWhiteSpace($secret)) {
+        return $secret
+    }
+
+    $vaultNameCandidates = @()
+    $secretNameCandidates = @()
+    if (-not [string]::IsNullOrWhiteSpace($normalizedTenantId)) {
+        $vaultNameCandidates += "ARBITRATION_CLIENT_SECRET_VAULT_NAME__${normalizedTenantId}"
+        $secretNameCandidates += "ARBITRATION_CLIENT_SECRET_SECRET_NAME__${normalizedTenantId}"
+    }
+    $vaultNameCandidates += 'ARBITRATION_CLIENT_SECRET_VAULT_NAME'
+    $secretNameCandidates += 'ARBITRATION_CLIENT_SECRET_SECRET_NAME'
+
+    $vaultName = Get-FirstEnvironmentVariableValue -Names $vaultNameCandidates
+    $secretName = Get-FirstEnvironmentVariableValue -Names $secretNameCandidates
+
+    if (-not [string]::IsNullOrWhiteSpace($vaultName) -and -not [string]::IsNullOrWhiteSpace($secretName)) {
+        try {
+            if (-not (Get-Module -Name Az.KeyVault)) {
+                Import-Module Az.KeyVault -ErrorAction Stop | Out-Null
+            }
+
+            $secret = Get-AzKeyVaultSecret -VaultName $vaultName -Name $secretName -AsPlainText -ErrorAction Stop
+            Write-Verbose "Retrieved client secret from Azure Key Vault '$vaultName' using secret '$secretName'."
+            return $secret
+        }
+        catch {
+            Write-Error "Failed to retrieve secret '$secretName' from Key Vault '$vaultName'. $_"
+            throw
+        }
+    }
+
+    return $null
+}
 
 Function GetAccessToken {
 Param (
-[Parameter (Mandatory=$true)][string]$ClientId, 
-[Parameter (Mandatory=$true)][string]$Resource, 
+[Parameter (Mandatory=$true)][string]$ClientId,
+[Parameter (Mandatory=$true)][string]$Resource,
 [Parameter (Mandatory=$true)][string]$TenantId
 )
-    $secret = If ($TenantId -eq '2e09f3a3-0520-461f-8474-052a8ed7814a') {"Sen8Q~ZHDZ0Br-~2l-hdEfWD7uhPl0OvHz7TYbOG"} ElseIf ($TenantId -eq 'production id here') {""} Else {""}
-    If ($secret -eq '') {
-        Write-Error 'Unknown TenantId'
+    $secret = Get-ClientSecret -TenantId $TenantId
+    if ([string]::IsNullOrWhiteSpace($secret)) {
+        Write-Error "Client secret not found. Set 'ARBITRATION_CLIENT_SECRET' (or the tenant-specific variant) or configure the Azure Key Vault environment variables."
         throw
     }
 
     try {
         # make service call
         Clear-Host
-    
+
         $url="https://login.microsoftonline.com/$TenantId/oauth2/token"
         $hdrs = @{}
         #$hdrs.Add("Content-Type","application/x-www-form-urlencoded")
         $hdrs.Add("Accept","*/*")
         $hdrs.Add("Accept-Encoding","gzip, deflate, br")
         $body = @{grant_type='client_credentials';client_id=$ClientId;client_secret=$secret;resource=$Resource;tenant_id=$TenantId}
-        
+
         Write-Host "Getting Access Token: $url ..."
 
         $result = Invoke-RestMethod -Uri $url -Method Post -Body $body -ContentType 'application/x-www-form-urlencoded' -Headers $hdrs
-    
+
         # return the token
         return $result.access_token
     }


### PR DESCRIPTION
## Summary
- remove the embedded client secret from `Arbitration-SendNSARequests.ps1`
- resolve the secret from environment variables or Azure Key Vault at runtime with new helper logic
- document the required environment variables and Key Vault settings for operators

## Testing
- not run (PowerShell is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c8be8289308326a44c19fad31965a5