### PR TITLE
Secure MPExternalDisputeAPI secret configuration

### DIFF
--- a/Arbitration/MPExternalDisputeAPI/MPExternalDisputeAPI.csproj
+++ b/Arbitration/MPExternalDisputeAPI/MPExternalDisputeAPI.csproj
@@ -9,6 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.6" />
     <PackageReference Include="Microsoft.Identity.Web" Version="1.25.0" />

--- a/Arbitration/MPExternalDisputeAPI/Program.cs
+++ b/Arbitration/MPExternalDisputeAPI/Program.cs
@@ -16,6 +16,7 @@ internal class Program
         const string corsPolicyName = "CorsPolicy";
 
         var builder = WebApplication.CreateBuilder(args);
+        SecureConfigurationHelper.ConfigureKeyVault(builder);
         // The following line enables Application Insights telemetry collection.
 //        builder.Services.AddApplicationInsightsTelemetry();
         var configuration = builder.Configuration;
@@ -118,10 +119,10 @@ internal class Program
 
         builder.Services.AddTransient<IImportDataSynchronizer, ImportDataSynchronizer>();
 
-        var cs = configuration.GetConnectionString("ConnStr");
+        var arbitrationConnectionString = SecureConfigurationHelper.GetRequiredSqlConnectionString(configuration, "ConnStr");
         builder.Services.AddDbContext<ArbitrationDbContext>(options =>
         {
-            options.UseSqlServer(cs, sqlServerOptionsAction: sqlOptions =>
+            options.UseSqlServer(arbitrationConnectionString, sqlServerOptionsAction: sqlOptions =>
             {
                 sqlOptions.EnableRetryOnFailure(
                     maxRetryCount: 5,
@@ -130,10 +131,10 @@ internal class Program
             });
         });
 
-        var idr_cs = configuration.GetConnectionString("IDRConnStr");
+        var idrConnectionString = SecureConfigurationHelper.GetRequiredSqlConnectionString(configuration, "IDRConnStr");
         builder.Services.AddDbContext<DisputeIdrDbContext>(options =>
         {
-            options.UseSqlServer(idr_cs, sqlServerOptionsAction: sqlOptions =>
+            options.UseSqlServer(idrConnectionString, sqlServerOptionsAction: sqlOptions =>
             {
                 sqlOptions.EnableRetryOnFailure(
                     maxRetryCount: 5,
@@ -141,6 +142,8 @@ internal class Program
                     errorNumbersToAdd: null);
             });
         });
+
+        SecureConfigurationHelper.EnsureApiKeyConfigured(configuration);
 
         //------------------- BUILD AND USE MIDDLEWARE ----------------------------------------------
         var app = builder.Build();

--- a/Arbitration/MPExternalDisputeAPI/Utility/SecureConfigurationHelper.cs
+++ b/Arbitration/MPExternalDisputeAPI/Utility/SecureConfigurationHelper.cs
@@ -1,0 +1,53 @@
+using System;
+using Azure.Extensions.AspNetCore.Configuration.Secrets;
+using Azure.Identity;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Configuration;
+
+namespace MPExternalDisputeAPI.Utility
+{
+    internal static class SecureConfigurationHelper
+    {
+        public static void ConfigureKeyVault(WebApplicationBuilder builder)
+        {
+            var keyVaultUriValue = builder.Configuration["KeyVault:Uri"];
+            if (string.IsNullOrWhiteSpace(keyVaultUriValue))
+            {
+                return;
+            }
+
+            if (!Uri.TryCreate(keyVaultUriValue, UriKind.Absolute, out var keyVaultUri))
+            {
+                throw new InvalidOperationException("The KeyVault:Uri configuration value is not a valid absolute URI.");
+            }
+
+            builder.Configuration.AddAzureKeyVault(keyVaultUri, new DefaultAzureCredential());
+        }
+
+        public static string GetRequiredSqlConnectionString(IConfiguration configuration, string connectionName)
+        {
+            var connectionString = configuration.GetConnectionString(connectionName);
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new InvalidOperationException($"The connection string '{connectionName}' was not found. Provide it via Azure Key Vault or environment variables.");
+            }
+
+            var connectionStringBuilder = new SqlConnectionStringBuilder(connectionString)
+            {
+                Encrypt = true,
+                TrustServerCertificate = false,
+            };
+
+            return connectionStringBuilder.ConnectionString;
+        }
+
+        public static void EnsureApiKeyConfigured(IConfiguration configuration)
+        {
+            if (string.IsNullOrWhiteSpace(configuration["ApiKey"]))
+            {
+                throw new InvalidOperationException("An API key was not configured. Provide the value via Azure Key Vault or environment variables.");
+            }
+        }
+    }
+}

--- a/Arbitration/MPExternalDisputeAPI/appsettings.json
+++ b/Arbitration/MPExternalDisputeAPI/appsettings.json
@@ -12,11 +12,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "ConnectionStrings": {
-    "ConnStr": "Server=tcp:de-dwsql13-sql.database.windows.net,1433;Initial Catalog=dE-HaloArbit-db;Persist Security Info=False;User ID=arbitration-calculator-appuser;Password=6wD0AD^zsU8X*92yzf12MHm0Pc;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30",
-    "IDRConnStr": "Data Source=10.102.72.4;Database=SRC_IDRSupport;Integrated Security=false;User ID=arbitapp_SRC_IDRSupport-appuser;Password=&g$Sjatf8i0TbZNZq55Z4a;MultipleActiveResultSets=True;Encrypt=False;TrustServerCertificate=True;Connection Timeout=30"
-
-  },
   "AllowedHosts": "*",
-  "ApiKey": "02e182fc9e404549ba2aa74cdf2f5ca6"
+  "KeyVault": {
+    "Uri": ""
+  }
 }


### PR DESCRIPTION
## Summary
- add an Azure Key Vault configuration helper and wire it into startup to source connection strings and API keys securely
- enforce TLS when building SQL Server connection strings and fail fast when required secrets are missing
- remove inline secrets from appsettings.json and add necessary Azure and SQL client packages

## Testing
- `dotnet build Arbitration/MPExternalDisputeAPI/MPExternalDisputeAPI.csproj` *(fails: `dotnet` command not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8be7f689c8326b4735e558e5d0a42