### PR TITLE
Remove duplicated provider constraints

### DIFF
--- a/platform/infra/envs/dev/providers.tf
+++ b/platform/infra/envs/dev/providers.tf
@@ -1,13 +1,3 @@
-
-terraform {
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "4.33.0"
-    }
-  }
-}
-
 locals {
   provider_subscription_id = try(trimspace(var.subscription_id), "") != "" ? var.subscription_id : null
   provider_tenant_id       = try(trimspace(var.tenant_id), "") != "" ? var.tenant_id : null

--- a/platform/infra/envs/prod/providers.tf
+++ b/platform/infra/envs/prod/providers.tf
@@ -1,12 +1,3 @@
-terraform {
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "4.33.0"
-    }
-  }
-}
-
 locals {
   provider_subscription_id = try(trimspace(var.subscription_id), "") != "" ? var.subscription_id : null
   provider_tenant_id       = try(trimspace(var.tenant_id), "") != "" ? var.tenant_id : null

--- a/platform/infra/envs/stage/providers.tf
+++ b/platform/infra/envs/stage/providers.tf
@@ -1,12 +1,3 @@
-terraform {
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "4.33.0"
-    }
-  }
-}
-
 locals {
   provider_subscription_id = try(trimspace(var.subscription_id), "") != "" ? var.subscription_id : null
   provider_tenant_id       = try(trimspace(var.tenant_id), "") != "" ? var.tenant_id : null


### PR DESCRIPTION
## Summary
- remove the redundant `terraform` blocks from each environment's `providers.tf`
- rely on the shared `versions.tf` files for provider source and version constraints

## Testing
- terraform -chdir=platform/infra/envs/dev init -backend=false *(fails: terraform not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b86517148326900d5fc4b9220000