### PR TITLE
Update Dockerfile base image and build dependencies

### DIFF
--- a/Arbitration/MPArbitration/Dockerfile.linux
+++ b/Arbitration/MPArbitration/Dockerfile.linux
@@ -1,30 +1,27 @@
-#FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
 #EXPOSE 443
 ENV ASPNETCORE_URLS=http://+:80;
 #ENV ASPNETCORE_URLS=http://+:80;https://+:443
 
-RUN apt-get update
-RUN apt-get -y install build-essential nodejs npm
-RUN npm --version
-RUN apt-get update
-
-
-
-#FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 
 WORKDIR /src
-COPY ["MPArbitration.csproj", "."]
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential nodejs npm \
+    && npm --version \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY ["MPArbitration.csproj", "."]
 RUN dotnet restore "./MPArbitration.csproj"
 COPY . .
 WORKDIR "/src/."
 
 ARG configuration=Release
 RUN dotnet build "MPArbitration.csproj" -c $configuration -o /app/build
+
 FROM build AS publish
 ARG configuration=Release
 RUN dotnet publish "MPArbitration.csproj" -c $configuration -o /app/publish /p:UseAppHost=false


### PR DESCRIPTION
## Summary
- switch the runtime stage to use the ASP.NET 6.0 base image and keep the SDK for build only
- install build-time packages in a single consolidated command that cleans up apt caches
- ensure only published application artifacts are copied into the final runtime image

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c891dc3be88326ae42d13d41dbb32f