### PR TITLE
Pin azuread and random provider versions

### DIFF
--- a/platform/infra/envs/dev/versions.tf
+++ b/platform/infra/envs/dev/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.3.0"
   required_providers {
     azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
-    azuread = { source = "hashicorp/azuread", version = "<latest>" }
-    random  = { source = "hashicorp/random",  version = "<latest>" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
   }
 }

--- a/platform/infra/envs/prod/versions.tf
+++ b/platform/infra/envs/prod/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.3.0"
   required_providers {
     azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
-    azuread = { source = "hashicorp/azuread", version = "<latest>" }
-    random  = { source = "hashicorp/random",  version = "<latest>" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
   }
 }

--- a/platform/infra/envs/stage/versions.tf
+++ b/platform/infra/envs/stage/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.3.0"
   required_providers {
     azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
-    azuread = { source = "hashicorp/azuread", version = "<latest>" }
-    random  = { source = "hashicorp/random",  version = "<latest>" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
   }
 }


### PR DESCRIPTION
## Summary
- pin the azuread provider to ~>2.40 across the dev, stage, and prod environment definitions
- pin the random provider to ~>3.5 across the dev, stage, and prod environment definitions

## Testing
- terraform init -upgrade *(fails: terraform binary is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b6d12e648326adfeea03c3325d42