### PR TITLE
Allow tracking terraform lockfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ override.tf.json
 *_override.tf
 *_override.tf.json
 *.tfplan
-**/.terraform.lock.hcl
 
 # Editor directories
 .vscode/


### PR DESCRIPTION
## Summary
- stop ignoring `.terraform.lock.hcl` files so that environment lockfiles can be committed

## Testing
- `terraform init` *(fails: terraform binary is not available in the execution environment, preventing lockfile generation)*

------
https://chatgpt.com/codex/tasks/task_e_68c89cdf907c8326b61f1b34fa0ae2cf