### PR TITLE
Add NAT and VPN gateway controls to environment variables

### DIFF
--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -1,4 +1,29 @@
 # -------------------------
+# Connectivity
+# -------------------------
+variable "enable_nat_gateway" {
+  description = "Flag to deploy a NAT Gateway for outbound connectivity."
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = var.enable_nat_gateway == false || var.nat_gateway_configuration != null
+    error_message = "nat_gateway_configuration must be provided when enable_nat_gateway is true."
+  }
+}
+
+variable "enable_vpn_gateway" {
+  description = "Flag to deploy a virtual network gateway for hybrid connectivity."
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = var.enable_vpn_gateway == false || var.vpn_gateway_configuration != null
+    error_message = "vpn_gateway_configuration must be provided when enable_vpn_gateway is true."
+  }
+}
+
+# -------------------------
 # Networking
 # -------------------------
 variable "vnet_address_space" {

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -1,3 +1,7 @@
+# -------------------------
+# Connectivity
+# -------------------------
+
 variable "enable_nat_gateway" {
   description = "Flag to deploy a NAT Gateway for outbound connectivity."
   type        = bool
@@ -6,6 +10,111 @@ variable "enable_nat_gateway" {
   validation {
     condition     = var.enable_nat_gateway == false || var.nat_gateway_configuration != null
     error_message = "nat_gateway_configuration must be provided when enable_nat_gateway is true."
+  }
+}
+
+variable "nat_gateway_configuration" {
+  description = "Configuration for the NAT Gateway when enabled."
+  type = object({
+    name                     = string
+    subnet_keys              = list(string)
+    public_ip_configurations = optional(list(object({
+      name              = string
+      allocation_method = optional(string, "Static")
+      sku               = optional(string, "Standard")
+      zones             = optional(list(string), [])
+      tags              = optional(map(string), {})
+    })), [])
+    public_ip_ids           = optional(list(string), [])
+    sku_name                = optional(string, "Standard")
+    idle_timeout_in_minutes = optional(number, 4)
+    zones                   = optional(list(string), [])
+    tags                    = optional(map(string), {})
+  })
+  default = null
+
+  validation {
+    condition = var.nat_gateway_configuration == null ? true : (
+      length(try(var.nat_gateway_configuration.public_ip_configurations, [])) +
+      length(try(var.nat_gateway_configuration.public_ip_ids, []))
+    ) > 0
+    error_message = "At least one public IP configuration or existing public IP ID must be provided for the NAT Gateway."
+  }
+
+  validation {
+    condition     = var.nat_gateway_configuration == null ? true : length(var.nat_gateway_configuration.subnet_keys) > 0
+    error_message = "At least one subnet key must be provided to associate the NAT Gateway."
+  }
+}
+
+variable "enable_vpn_gateway" {
+  description = "Flag to deploy a virtual network gateway for hybrid connectivity."
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = var.enable_vpn_gateway == false || var.vpn_gateway_configuration != null
+    error_message = "vpn_gateway_configuration must be provided when enable_vpn_gateway is true."
+  }
+}
+
+variable "vpn_gateway_configuration" {
+  description = "Configuration for the virtual network gateway when enabled."
+  type = object({
+    name                 = string
+    gateway_subnet_key   = string
+    sku                  = string
+    gateway_type         = optional(string, "Vpn")
+    vpn_type             = optional(string, "RouteBased")
+    active_active        = optional(bool, false)
+    enable_bgp           = optional(bool, false)
+    generation           = optional(string)
+    ip_configuration_name = optional(string, "default")
+    custom_routes        = optional(list(string), [])
+    public_ip = optional(object({
+      name              = string
+      allocation_method = optional(string, "Static")
+      sku               = optional(string, "Standard")
+      zones             = optional(list(string), [])
+      tags              = optional(map(string), {})
+    }))
+    public_ip_id            = optional(string)
+    vpn_client_configuration = optional(object({
+      address_space         = list(string)
+      vpn_client_protocols  = optional(list(string), ["OpenVPN"])
+      vpn_auth_types        = optional(list(string), [])
+      aad_tenant            = optional(string)
+      aad_audience          = optional(string)
+      aad_issuer            = optional(string)
+      radius_server_address = optional(string)
+      radius_server_secret  = optional(string)
+      root_certificates = optional(list(object({
+        name             = string
+        public_cert_data = string
+      })), [])
+      revoked_certificates = optional(list(object({
+        name       = string
+        thumbprint = string
+      })), [])
+    }))
+    bgp_settings = optional(object({
+      asn         = number
+      peer_weight = optional(number)
+      peering_addresses = optional(list(object({
+        ip_configuration_name = string
+        apipa_addresses       = list(string)
+      })), [])
+    }))
+    tags = optional(map(string), {})
+  })
+  default = null
+
+  validation {
+    condition = var.vpn_gateway_configuration == null ? true : (
+      (try(var.vpn_gateway_configuration.public_ip, null) != null ? 1 : 0) +
+      (try(var.vpn_gateway_configuration.public_ip_id, null) != null && try(trim(var.vpn_gateway_configuration.public_ip_id), "") != "" ? 1 : 0)
+    ) > 0
+    error_message = "Either a public_ip definition or public_ip_id must be supplied for the virtual network gateway."
   }
 }
 

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -1,3 +1,7 @@
+# -------------------------
+# Connectivity
+# -------------------------
+
 variable "enable_nat_gateway" {
   description = "Flag to deploy a NAT Gateway for outbound connectivity."
   type        = bool
@@ -6,6 +10,111 @@ variable "enable_nat_gateway" {
   validation {
     condition     = var.enable_nat_gateway == false || var.nat_gateway_configuration != null
     error_message = "nat_gateway_configuration must be provided when enable_nat_gateway is true."
+  }
+}
+
+variable "nat_gateway_configuration" {
+  description = "Configuration for the NAT Gateway when enabled."
+  type = object({
+    name                     = string
+    subnet_keys              = list(string)
+    public_ip_configurations = optional(list(object({
+      name              = string
+      allocation_method = optional(string, "Static")
+      sku               = optional(string, "Standard")
+      zones             = optional(list(string), [])
+      tags              = optional(map(string), {})
+    })), [])
+    public_ip_ids           = optional(list(string), [])
+    sku_name                = optional(string, "Standard")
+    idle_timeout_in_minutes = optional(number, 4)
+    zones                   = optional(list(string), [])
+    tags                    = optional(map(string), {})
+  })
+  default = null
+
+  validation {
+    condition = var.nat_gateway_configuration == null ? true : (
+      length(try(var.nat_gateway_configuration.public_ip_configurations, [])) +
+      length(try(var.nat_gateway_configuration.public_ip_ids, []))
+    ) > 0
+    error_message = "At least one public IP configuration or existing public IP ID must be provided for the NAT Gateway."
+  }
+
+  validation {
+    condition     = var.nat_gateway_configuration == null ? true : length(var.nat_gateway_configuration.subnet_keys) > 0
+    error_message = "At least one subnet key must be provided to associate the NAT Gateway."
+  }
+}
+
+variable "enable_vpn_gateway" {
+  description = "Flag to deploy a virtual network gateway for hybrid connectivity."
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = var.enable_vpn_gateway == false || var.vpn_gateway_configuration != null
+    error_message = "vpn_gateway_configuration must be provided when enable_vpn_gateway is true."
+  }
+}
+
+variable "vpn_gateway_configuration" {
+  description = "Configuration for the virtual network gateway when enabled."
+  type = object({
+    name                 = string
+    gateway_subnet_key   = string
+    sku                  = string
+    gateway_type         = optional(string, "Vpn")
+    vpn_type             = optional(string, "RouteBased")
+    active_active        = optional(bool, false)
+    enable_bgp           = optional(bool, false)
+    generation           = optional(string)
+    ip_configuration_name = optional(string, "default")
+    custom_routes        = optional(list(string), [])
+    public_ip = optional(object({
+      name              = string
+      allocation_method = optional(string, "Static")
+      sku               = optional(string, "Standard")
+      zones             = optional(list(string), [])
+      tags              = optional(map(string), {})
+    }))
+    public_ip_id            = optional(string)
+    vpn_client_configuration = optional(object({
+      address_space         = list(string)
+      vpn_client_protocols  = optional(list(string), ["OpenVPN"])
+      vpn_auth_types        = optional(list(string), [])
+      aad_tenant            = optional(string)
+      aad_audience          = optional(string)
+      aad_issuer            = optional(string)
+      radius_server_address = optional(string)
+      radius_server_secret  = optional(string)
+      root_certificates = optional(list(object({
+        name             = string
+        public_cert_data = string
+      })), [])
+      revoked_certificates = optional(list(object({
+        name       = string
+        thumbprint = string
+      })), [])
+    }))
+    bgp_settings = optional(object({
+      asn         = number
+      peer_weight = optional(number)
+      peering_addresses = optional(list(object({
+        ip_configuration_name = string
+        apipa_addresses       = list(string)
+      })), [])
+    }))
+    tags = optional(map(string), {})
+  })
+  default = null
+
+  validation {
+    condition = var.vpn_gateway_configuration == null ? true : (
+      (try(var.vpn_gateway_configuration.public_ip, null) != null ? 1 : 0) +
+      (try(var.vpn_gateway_configuration.public_ip_id, null) != null && try(trim(var.vpn_gateway_configuration.public_ip_id), "") != "" ? 1 : 0)
+    ) > 0
+    error_message = "Either a public_ip definition or public_ip_id must be supplied for the virtual network gateway."
   }
 }
 


### PR DESCRIPTION
## Summary
- add NAT and VPN gateway enablement flags to each environment variable definition
- provide NAT and VPN gateway configuration schemas for the stage and prod environments to drive module usage

## Testing
- terraform fmt platform/infra/envs/dev/variables.tf *(fails: terraform CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8cc6bfa48832681a94e30006bdf8a