### PR TITLE
Align dev variables with stage and prod

### DIFF
--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -1,6 +1,7 @@
 # -------------------------
 # Connectivity
 # -------------------------
+
 variable "enable_nat_gateway" {
   description = "Flag to deploy a NAT Gateway for outbound connectivity."
   type        = bool
@@ -10,70 +11,6 @@ variable "enable_nat_gateway" {
     condition     = var.enable_nat_gateway == false || var.nat_gateway_configuration != null
     error_message = "nat_gateway_configuration must be provided when enable_nat_gateway is true."
   }
-}
-
-variable "enable_vpn_gateway" {
-  description = "Flag to deploy a virtual network gateway for hybrid connectivity."
-  type        = bool
-  default     = false
-
-  validation {
-    condition     = var.enable_vpn_gateway == false || var.vpn_gateway_configuration != null
-    error_message = "vpn_gateway_configuration must be provided when enable_vpn_gateway is true."
-  }
-}
-
-# -------------------------
-# Networking
-# -------------------------
-variable "vnet_address_space" {
-  description = "Address space assigned to the virtual network."
-  type        = list(string)
-}
-
-variable "vnet_dns_servers" {
-  description = "Optional custom DNS servers applied to the virtual network."
-  type        = list(string)
-  default     = []
-}
-
-variable "subnets" {
-  description = "Map of subnet definitions keyed by subnet name."
-  type = map(object({
-    address_prefixes  = list(string)
-    service_endpoints = optional(list(string), [])
-    delegations = optional(list(object({
-      name = string
-      service_delegation = object({
-        name    = string
-        actions = list(string)
-      })
-    })), [])
-  }))
-}
-
-variable "subnet_network_security_rules" {
-  description = <<-DOC
-  Map of network security rule sets keyed by subnet name. Each entry should
-  match the `security_rules` input for the `network-security-group` module and
-  defaults to an empty map, resulting in only the built-in Azure NSG rules.
-  DOC
-  type = map(map(object({
-    priority                     = number
-    direction                    = optional(string, "Inbound")
-    access                       = optional(string, "Allow")
-    protocol                     = optional(string, "*")
-    source_port_range            = optional(string)
-    source_port_ranges           = optional(list(string))
-    destination_port_range       = optional(string)
-    destination_port_ranges      = optional(list(string))
-    source_address_prefix        = optional(string)
-    source_address_prefixes      = optional(list(string))
-    destination_address_prefix   = optional(string)
-    destination_address_prefixes = optional(list(string))
-    description                  = optional(string)
-  })))
-  default = {}
 }
 
 variable "nat_gateway_configuration" {
@@ -107,6 +44,17 @@ variable "nat_gateway_configuration" {
   validation {
     condition     = var.nat_gateway_configuration == null ? true : length(var.nat_gateway_configuration.subnet_keys) > 0
     error_message = "At least one subnet key must be provided to associate the NAT Gateway."
+  }
+}
+
+variable "enable_vpn_gateway" {
+  description = "Flag to deploy a virtual network gateway for hybrid connectivity."
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = var.enable_vpn_gateway == false || var.vpn_gateway_configuration != null
+    error_message = "vpn_gateway_configuration must be provided when enable_vpn_gateway is true."
   }
 }
 
@@ -168,4 +116,57 @@ variable "vpn_gateway_configuration" {
     ) > 0
     error_message = "Either a public_ip definition or public_ip_id must be supplied for the virtual network gateway."
   }
+}
+
+# -------------------------
+# Networking
+# -------------------------
+variable "vnet_address_space" {
+  description = "Address space assigned to the virtual network."
+  type        = list(string)
+}
+
+variable "vnet_dns_servers" {
+  description = "Optional custom DNS servers applied to the virtual network."
+  type        = list(string)
+  default     = []
+}
+
+variable "subnets" {
+  description = "Map of subnet definitions keyed by subnet name."
+  type = map(object({
+    address_prefixes  = list(string)
+    service_endpoints = optional(list(string), [])
+    delegations = optional(list(object({
+      name = string
+      service_delegation = object({
+        name    = string
+        actions = list(string)
+      })
+    })), [])
+  }))
+}
+
+variable "subnet_network_security_rules" {
+  description = <<-DOC
+  Map of network security rule sets keyed by subnet name. Each entry should
+  match the `security_rules` input for the `network-security-group` module and
+  defaults to an empty map, resulting in only the built-in Azure NSG rules.
+  DOC
+  type = map(map(object({
+    priority                     = number
+    direction                    = optional(string, "Inbound")
+    access                       = optional(string, "Allow")
+    protocol                     = optional(string, "*")
+    source_port_range            = optional(string)
+    source_port_ranges           = optional(list(string))
+    destination_port_range       = optional(string)
+    destination_port_ranges      = optional(list(string))
+    source_address_prefix        = optional(string)
+    source_address_prefixes      = optional(list(string))
+    destination_address_prefix   = optional(string)
+    destination_address_prefixes = optional(list(string))
+    description                  = optional(string)
+  })))
+  default = {}
 }


### PR DESCRIPTION
## Summary
- align the dev connectivity variables with stage/prod so NAT and VPN gateway configuration blocks and validations match across environments
- keep the networking variables grouped after connectivity with consistent comments and defaults

## Testing
- not run (terraform CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c8ce778a348326b1519b89237c8145