### PR TITLE
Update stage network to 10.30.0.0/16

### DIFF
--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -16,14 +16,12 @@ tags = {
 # -------------------------
 # Networking
 # -------------------------
-vnet_address_space = ["10.20.0.0/16"]
+vnet_address_space = ["10.30.0.0/16"]
 subnets = {
-  gateway = {
-    address_prefixes = ["10.20.0.0/24"]
-  }
-  web = {
-    address_prefixes = ["10.20.1.0/24"]
-  }
+  gateway = { address_prefixes = ["10.30.0.0/24"] }
+  web     = { address_prefixes = ["10.30.1.0/24"] }
+  data    = { address_prefixes = ["10.30.2.0/24"] }
+  mgmt    = { address_prefixes = ["10.30.3.0/24"] }
 }
 
 # For module using subnet keys
@@ -46,7 +44,7 @@ dns_zone_name = "az.halomd.com"
 dns_a_records = {
   "api-stage" = {
     ttl     = 3600
-    records = ["10.20.1.10"]
+    records = ["10.30.1.10"]
   }
 }
 


### PR DESCRIPTION
## Summary
- update the stage virtual network address space and define gateway, web, data, and mgmt subnets under 10.30.0.0/16
- point the stage API DNS A record to 10.30.1.10

## Testing
- terraform plan *(fails: terraform binary is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d7974220832689832800a98b8468