### PR TITLE
Inject backend subscription and tenant IDs at runtime

### DIFF
--- a/.ado/templates/tf-apply.yml
+++ b/.ado/templates/tf-apply.yml
@@ -64,9 +64,15 @@ jobs:
               cd platform/infra/envs/${{ parameters.envName }}
 
               # Init backend (reconfigure ensures the local .terraform matches this backend)
-              terraform init -reconfigure \
-                -backend-config=backend.tfvars \
-                -lock-timeout='${{ parameters.lockTimeout }}'
+              declare -a BACKEND_CONFIG_ARGS=(-backend-config=backend.tfvars)
+              if [[ -n "${AZ_SUBSCRIPTION_ID:-}" ]]; then
+                BACKEND_CONFIG_ARGS+=(-backend-config="subscription_id=${AZ_SUBSCRIPTION_ID}")
+              fi
+              if [[ -n "${AZ_TENANT_ID:-}" ]]; then
+                BACKEND_CONFIG_ARGS+=(-backend-config="tenant_id=${AZ_TENANT_ID}")
+              fi
+
+              terraform init -reconfigure "${BACKEND_CONFIG_ARGS[@]}" -lock-timeout='${{ parameters.lockTimeout }}'
 
               # Apply the previously generated plan file (NO extra '.' at the end)
               terraform apply -input=false -auto-approve \

--- a/.ado/templates/tf-plan.yml
+++ b/.ado/templates/tf-plan.yml
@@ -96,14 +96,17 @@ jobs:
         fi
 
         cd platform/infra/envs/${{ parameters.envName }}
+        declare -a BACKEND_CONFIG_ARGS=(-backend-config=backend.tfvars)
         if [[ -n "${AZ_SUBSCRIPTION_ID:-}" ]]; then
           SUB_TENANT_VAR_FLAGS="${SUB_TENANT_VAR_FLAGS} -var \"subscription_id=${AZ_SUBSCRIPTION_ID}\""
+          BACKEND_CONFIG_ARGS+=(-backend-config="subscription_id=${AZ_SUBSCRIPTION_ID}")
         fi
         if [[ -n "${AZ_TENANT_ID:-}" ]]; then
           SUB_TENANT_VAR_FLAGS="${SUB_TENANT_VAR_FLAGS} -var \"tenant_id=${AZ_TENANT_ID}\""
+          BACKEND_CONFIG_ARGS+=(-backend-config="tenant_id=${AZ_TENANT_ID}")
         fi
 
-        terraform init -reconfigure -backend-config=backend.tfvars -lock-timeout='${{ parameters.lockTimeout }}'
+        terraform init -reconfigure "${BACKEND_CONFIG_ARGS[@]}" -lock-timeout='${{ parameters.lockTimeout }}'
         terraform plan -input=false -var-file=terraform.tfvars ${{ parameters.extraVarFlags }} ${SUB_TENANT_VAR_FLAGS} ${AKV_VAR_FLAGS} -out "$BUILD_SOURCESDIRECTORY/tfplan-${{ parameters.envName }}.tfplan"
   - task: PublishPipelineArtifact@1
     inputs:

--- a/docs/DEV-Deploy-From-Laptop.md
+++ b/docs/DEV-Deploy-From-Laptop.md
@@ -38,10 +38,26 @@ flowchart TD
 flowchart TD
   L1[Install: Terraform 1.7.5 + Azure CLI]
   L2[az login + select subscription]
-  L3[cd platform/infra/envs/dev]
-  L4[terraform init -reconfigure -backend-config=backend.tfvars]
-  L5[terraform plan -var-file=terraform.tfvars -out tfplan-dev.tfplan]
-  L6[terraform apply tfplan-dev.tfplan]
-  L7[Verify in Azure]
-  L1-->L2-->L3-->L4-->L5-->L6-->L7
+  L3[export AZ\_SUBSCRIPTION\_ID/AZ\_TENANT\_ID]
+  L4[cd platform/infra/envs/dev]
+  L5[terraform init -reconfigure\n- backend-config=backend.tfvars\n- backend-config=\"subscription_id=$AZ_SUBSCRIPTION_ID\"\n- backend-config=\"tenant_id=$AZ_TENANT_ID\"]
+  L6[terraform plan -var-file=terraform.tfvars -out tfplan-dev.tfplan]
+  L7[terraform apply tfplan-dev.tfplan]
+  L8[Verify in Azure]
+  L1-->L2-->L3-->L4-->L5-->L6-->L7-->L8
 ```
+
+### Supplying the backend subscription & tenant IDs securely
+
+- **CI/CD:** Store `AZ_SUBSCRIPTION_ID` and `AZ_TENANT_ID` as secret pipeline variables (for example in the `terraform-<env>` variable group). The Azure CLI task exposes them as environment variables and the pipeline templates inject them into `terraform init` automatically.
+- **Local runs:** Export the variables from your current Azure CLI context before running `terraform init`:
+
+  ```bash
+  export AZ_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+  export AZ_TENANT_ID=$(az account show --query tenantId -o tsv)
+
+  terraform init -reconfigure \
+    -backend-config=backend.tfvars \
+    -backend-config="subscription_id=${AZ_SUBSCRIPTION_ID}" \
+    -backend-config="tenant_id=${AZ_TENANT_ID}"
+  ```

--- a/docs/GLOBAL-VARIABLES.md
+++ b/docs/GLOBAL-VARIABLES.md
@@ -17,6 +17,8 @@
 - `AZ_SUBSCRIPTION_ID` = `<subscription guid>`
 - `AZ_TENANT_ID` = `<tenant guid>`
 
+  > Mark both as **secret** variables so the pipeline can inject them into `terraform init` without storing the GUIDs in source control.
+
 - `AKV_ENABLE_DYNAMIC_IP_DEV` = `true`   # temp IP allow during plan on hosted agents
 - `AKV_ENABLE_DYNAMIC_IP_STAGE` = `false`
 - `AKV_ENABLE_DYNAMIC_IP_PROD` = `false`

--- a/platform/infra/envs/dev/backend.tfvars
+++ b/platform/infra/envs/dev/backend.tfvars
@@ -4,5 +4,6 @@ storage_account_name = "deveus2terraform"
 container_name = "arbit"
 key = "arbit/dev.tfstate"
 use_azuread_auth = true
-subscription_id = "930755b1-ef22-4721-a31a-1b6fbecf7da6"
-tenant_id = "70750cc4-6f21-4c27-bb0e-8b7e66bcb2dd"
+# subscription_id and tenant_id are supplied at runtime (e.g. via
+# AZ_SUBSCRIPTION_ID / AZ_TENANT_ID environment variables in CI or your
+# local shell).


### PR DESCRIPTION
## Summary
- remove hard-coded subscription and tenant IDs from the dev backend configuration and rely on runtime injection
- update the Terraform pipeline templates to pass backend subscription/tenant IDs from environment variables during init
- document how to supply the backend IDs securely for CI and local workflows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8e14ad11c8326be7234a593cbf992