### PR TITLE
Add subscription context variables for dev environment

### DIFF
--- a/.ado/templates/tf-plan.yml
+++ b/.ado/templates/tf-plan.yml
@@ -67,7 +67,6 @@ jobs:
         SECRET_LOGIN='${{ parameters.akvSecretSqlAdminLoginName }}'
         SECRET_PASS='${{ parameters.akvSecretSqlAdminPasswordName }}'
         AKV_VAR_FLAGS=""
-        SUB_TENANT_VAR_FLAGS=""
 
         if [[ "$USE_AKV" == "true" && -n "$KV_NAME" ]]; then
           if [[ "$DYN_IP" == "true" ]]; then
@@ -97,14 +96,14 @@ jobs:
 
         cd platform/infra/envs/${{ parameters.envName }}
         if [[ -n "${AZ_SUBSCRIPTION_ID:-}" ]]; then
-          SUB_TENANT_VAR_FLAGS="${SUB_TENANT_VAR_FLAGS} -var \"subscription_id=${AZ_SUBSCRIPTION_ID}\""
+          export TF_VAR_subscription_id="${AZ_SUBSCRIPTION_ID}"
         fi
         if [[ -n "${AZ_TENANT_ID:-}" ]]; then
-          SUB_TENANT_VAR_FLAGS="${SUB_TENANT_VAR_FLAGS} -var \"tenant_id=${AZ_TENANT_ID}\""
+          export TF_VAR_tenant_id="${AZ_TENANT_ID}"
         fi
 
         terraform init -reconfigure -backend-config=backend.tfvars -lock-timeout='${{ parameters.lockTimeout }}'
-        terraform plan -input=false -var-file=terraform.tfvars ${{ parameters.extraVarFlags }} ${SUB_TENANT_VAR_FLAGS} ${AKV_VAR_FLAGS} -out "$BUILD_SOURCESDIRECTORY/tfplan-${{ parameters.envName }}.tfplan"
+        terraform plan -input=false -var-file=terraform.tfvars ${{ parameters.extraVarFlags }} ${AKV_VAR_FLAGS} -out "$BUILD_SOURCESDIRECTORY/tfplan-${{ parameters.envName }}.tfplan"
   - task: PublishPipelineArtifact@1
     inputs:
       targetPath: '$(Build.SourcesDirectory)/tfplan-${{ parameters.envName }}.tfplan'

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -22,6 +22,24 @@ variable "tags" {
   default     = {}
 }
 
+variable "kv_cicd_principal_id" {
+  description = "Optional object ID for the CI/CD principal that needs access to Key Vault secrets."
+  type        = string
+  default     = null
+}
+
+variable "subscription_id" {
+  description = "Optional Azure subscription ID override when the authenticated context differs from the desired target."
+  type        = string
+  default     = null
+}
+
+variable "tenant_id" {
+  description = "Optional Azure AD tenant ID override when the authenticated context differs from the desired target."
+  type        = string
+  default     = null
+}
+
 # -------------------------
 # Bastion
 # -------------------------


### PR DESCRIPTION
## Summary
- add optional CI/CD principal, subscription, and tenant variables to the dev Terraform configuration
- export subscription and tenant IDs from Azure DevOps variables before running terraform plan so the new inputs are populated

## Testing
- terraform fmt platform/infra/envs/dev/variables.tf *(fails: terraform CLI not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e13d345883269db9148e291b54ed