### PR TITLE
Remove duplicate required providers block

### DIFF
--- a/platform/infra/envs/dev/providers.tf
+++ b/platform/infra/envs/dev/providers.tf
@@ -1,20 +1,3 @@
-terraform {
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "4.33.0"
-    }
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "~> 2.0"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.0"
-    }
-  }
-}
-
 locals {
   provider_subscription_id = try(trimspace(var.subscription_id), "") != "" ? var.subscription_id : null
   provider_tenant_id       = try(trimspace(var.tenant_id), "") != "" ? var.tenant_id : null


### PR DESCRIPTION
## Summary
- remove the redundant required_providers block from the dev environment providers configuration so version constraints live in versions.tf

## Testing
- terraform fmt -recursive *(fails: terraform not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e13b81b88326bc69eabfdca6f8a0