### PR TITLE
Add DNS zone management modules for stage and prod

### DIFF
--- a/platform/infra/envs/prod/main.tf
+++ b/platform/infra/envs/prod/main.tf
@@ -89,6 +89,16 @@ module "resource_group" {
   tags     = var.tags
 }
 
+module "dns_zone" {
+  count               = length(trimspace(coalesce(var.dns_zone_name, ""))) > 0 ? 1 : 0
+  source              = "../../Azure/modules/dns-zone"
+  zone_name           = var.dns_zone_name
+  resource_group_name = module.resource_group.name
+  tags                = var.tags
+  a_records           = var.dns_a_records
+  cname_records       = var.dns_cname_records
+}
+
 module "network" {
   source              = "../../Azure/modules/network"
   name                = "vnet-${var.project_name}-${var.env_name}"

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -192,6 +192,33 @@ variable "subnet_network_security_rules" {
 }
 
 # -------------------------
+# DNS
+# -------------------------
+variable "dns_zone_name" {
+  description = "Name of the DNS zone to manage."
+  type        = string
+  default     = null
+}
+
+variable "dns_a_records" {
+  description = "Map of DNS A records to create within the zone keyed by record name."
+  type = map(object({
+    ttl     = number
+    records = list(string)
+  }))
+  default = {}
+}
+
+variable "dns_cname_records" {
+  description = "Map of DNS CNAME records to create within the zone keyed by record name."
+  type = map(object({
+    ttl   = number
+    record = string
+  }))
+  default = {}
+}
+
+# -------------------------
 # Key Vault & Storage networking
 # -------------------------
 variable "kv_public_network_access" {

--- a/platform/infra/envs/stage/main.tf
+++ b/platform/infra/envs/stage/main.tf
@@ -89,6 +89,16 @@ module "resource_group" {
   tags     = var.tags
 }
 
+module "dns_zone" {
+  count               = length(trimspace(coalesce(var.dns_zone_name, ""))) > 0 ? 1 : 0
+  source              = "../../Azure/modules/dns-zone"
+  zone_name           = var.dns_zone_name
+  resource_group_name = module.resource_group.name
+  tags                = var.tags
+  a_records           = var.dns_a_records
+  cname_records       = var.dns_cname_records
+}
+
 module "network" {
   source              = "../../Azure/modules/network"
   name                = "vnet-${var.project_name}-${var.env_name}"
@@ -98,8 +108,6 @@ module "network" {
   dns_servers         = var.vnet_dns_servers
   subnets             = var.subnets
   tags                = var.tags
-  a_records           = var.dns_a_records
-  cname_records       = var.dns_cname_records
 }
 
 # NSGs

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -192,6 +192,33 @@ variable "subnet_network_security_rules" {
 }
 
 # -------------------------
+# DNS
+# -------------------------
+variable "dns_zone_name" {
+  description = "Name of the DNS zone to manage."
+  type        = string
+  default     = null
+}
+
+variable "dns_a_records" {
+  description = "Map of DNS A records to create within the zone keyed by record name."
+  type = map(object({
+    ttl     = number
+    records = list(string)
+  }))
+  default = {}
+}
+
+variable "dns_cname_records" {
+  description = "Map of DNS CNAME records to create within the zone keyed by record name."
+  type = map(object({
+    ttl   = number
+    record = string
+  }))
+  default = {}
+}
+
+# -------------------------
 # Key Vault & Storage networking
 # -------------------------
 variable "kv_public_network_access" {


### PR DESCRIPTION
## Summary
- add the shared DNS zone module to the stage and prod compositions and remove the legacy record arguments from the network module
- expose inputs for the DNS zone name along with A and CNAME record maps in each environment

## Testing
- terraform fmt platform/infra/envs/stage *(fails: terraform binary is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c96a47fc208326ac31f62b102c5361