### PR TITLE
Add application gateway module to environment stacks

### DIFF
--- a/platform/infra/envs/dev/main.tf
+++ b/platform/infra/envs/dev/main.tf
@@ -3,6 +3,7 @@
 locals {
   rg_name                      = "rg-${var.project_name}-${var.env_name}"
   kv_name                      = "kv-${var.project_name}-${var.env_name}"
+  app_gateway_name             = "agw-${var.project_name}-${var.env_name}"
   bastion_name                 = "bas-${var.project_name}-${var.env_name}"
   kv_private_endpoint_name     = "pep-${var.project_name}-${var.env_name}-kv"
   storage_private_endpoint_name = "pep-${var.project_name}-${var.env_name}-st"
@@ -133,6 +134,18 @@ module "vpn_gateway" {
   vpn_client_configuration     = each.value.vpn_client_configuration
   bgp_settings                 = each.value.bgp_settings
   tags                         = merge(var.tags, each.value.tags)
+}
+
+# Application Gateway
+module "app_gateway" {
+  source              = "../../Azure/modules/app-gateway"
+  name                = local.app_gateway_name
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  subnet_id = var.app_gateway_subnet_id != null && trimspace(var.app_gateway_subnet_id) != "" ? var.app_gateway_subnet_id : module.network.subnet_ids[var.app_gateway_subnet_key]
+  fqdn_prefix   = var.app_gateway_fqdn_prefix
+  backend_fqdns = var.app_gateway_backend_fqdns
+  tags          = var.tags
 }
 
 # Bastion

--- a/platform/infra/envs/dev/terraform.tfvars
+++ b/platform/infra/envs/dev/terraform.tfvars
@@ -24,6 +24,16 @@ subnets = {
   mgmt    = { address_prefixes = ["10.20.3.0/24"] }
 }
 
+# -------------------------
+# Application Gateway
+# -------------------------
+app_gateway_subnet_key    = "gateway"
+app_gateway_fqdn_prefix   = "agw-arbit-dev"
+app_gateway_backend_fqdns = [
+  "app-halomdweb-dev.azurewebsites.net",
+  "app-arbit-arb-dev.azurewebsites.net",
+]
+
 # Subnet references for optional modules
 bastion_subnet_key                  = "mgmt"
 kv_private_endpoint_subnet_key      = "data"

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -41,6 +41,50 @@ variable "tenant_id" {
 }
 
 # -------------------------
+# Application Gateway
+# -------------------------
+variable "app_gateway_subnet_key" {
+  description = "Key of the subnet reserved for the Application Gateway."
+  type        = string
+
+  validation {
+    condition     = try(trimspace(var.app_gateway_subnet_key), "") != ""
+    error_message = "app_gateway_subnet_key must not be empty."
+  }
+}
+
+variable "app_gateway_subnet_id" {
+  description = "Optional explicit subnet resource ID used for the Application Gateway when not managed in this configuration."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.app_gateway_subnet_id == null || trimspace(var.app_gateway_subnet_id) != ""
+    error_message = "app_gateway_subnet_id cannot be an empty string; remove it instead."
+  }
+}
+
+variable "app_gateway_fqdn_prefix" {
+  description = "Domain name label applied to the Application Gateway public IP."
+  type        = string
+
+  validation {
+    condition     = try(trimspace(var.app_gateway_fqdn_prefix), "") != ""
+    error_message = "app_gateway_fqdn_prefix must not be empty."
+  }
+}
+
+variable "app_gateway_backend_fqdns" {
+  description = "List of backend hostnames routed through the Application Gateway."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.app_gateway_backend_fqdns) > 0
+    error_message = "At least one backend hostname must be provided for the Application Gateway."
+  }
+}
+
+# -------------------------
 # Bastion
 # -------------------------
 variable "enable_bastion" {

--- a/platform/infra/envs/prod/main.tf
+++ b/platform/infra/envs/prod/main.tf
@@ -158,6 +158,18 @@ module "storage_private_endpoint" {
   ] : []
 }
 
+# Application Gateway
+module "app_gateway" {
+  source              = "../../Azure/modules/app-gateway"
+  name                = local.app_gateway_name
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  subnet_id = var.app_gateway_subnet_id != null && trimspace(var.app_gateway_subnet_id) != "" ? var.app_gateway_subnet_id : module.network.subnet_ids[var.app_gateway_subnet_key]
+  fqdn_prefix   = var.app_gateway_fqdn_prefix
+  backend_fqdns = var.app_gateway_backend_fqdns
+  tags          = var.tags
+}
+
 # NAT Gateway
 module "nat_gateway" {
   for_each = local.nat_gateway_settings == null ? {} : { default = local.nat_gateway_settings }

--- a/platform/infra/envs/prod/terraform.tfvars
+++ b/platform/infra/envs/prod/terraform.tfvars
@@ -24,10 +24,11 @@ subnets = {
   mgmt    = { address_prefixes = ["10.40.3.0/24"] }
 }
 
-# For module using subnet keys
-app_gateway_subnet_key  = "gateway"
-
-# For module using direct subnet id
+# -------------------------
+# Application Gateway
+# -------------------------
+app_gateway_subnet_key = "gateway"
+# Optional override when reusing an existing subnet
 app_gateway_subnet_id = "/subscriptions/930755b1-ef22-4721-a31a-1b6fbecf7da6/resourceGroups/rg-arbit-prod/providers/Microsoft.Network/virtualNetworks/vnet-arbit-prod/subnets/appgw"
 
 app_gateway_fqdn_prefix   = "agw-arbit-prod"

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -1,4 +1,49 @@
 # -------------------------
+# Application Gateway
+# -------------------------
+
+variable "app_gateway_subnet_key" {
+  description = "Key of the subnet reserved for the Application Gateway."
+  type        = string
+
+  validation {
+    condition     = try(trimspace(var.app_gateway_subnet_key), "") != ""
+    error_message = "app_gateway_subnet_key must not be empty."
+  }
+}
+
+variable "app_gateway_subnet_id" {
+  description = "Optional explicit subnet resource ID used for the Application Gateway when managed outside of this workspace."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.app_gateway_subnet_id == null || trimspace(var.app_gateway_subnet_id) != ""
+    error_message = "app_gateway_subnet_id cannot be an empty string; remove it instead."
+  }
+}
+
+variable "app_gateway_fqdn_prefix" {
+  description = "Domain name label applied to the Application Gateway public IP."
+  type        = string
+
+  validation {
+    condition     = try(trimspace(var.app_gateway_fqdn_prefix), "") != ""
+    error_message = "app_gateway_fqdn_prefix must not be empty."
+  }
+}
+
+variable "app_gateway_backend_fqdns" {
+  description = "List of backend hostnames routed through the Application Gateway."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.app_gateway_backend_fqdns) > 0
+    error_message = "At least one backend hostname must be provided for the Application Gateway."
+  }
+}
+
+# -------------------------
 # Connectivity
 # -------------------------
 

--- a/platform/infra/envs/stage/main.tf
+++ b/platform/infra/envs/stage/main.tf
@@ -160,6 +160,18 @@ module "storage_private_endpoint" {
   ] : []
 }
 
+# Application Gateway
+module "app_gateway" {
+  source              = "../../Azure/modules/app-gateway"
+  name                = local.app_gateway_name
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  subnet_id = var.app_gateway_subnet_id != null && trimspace(var.app_gateway_subnet_id) != "" ? var.app_gateway_subnet_id : module.network.subnet_ids[var.app_gateway_subnet_key]
+  fqdn_prefix   = var.app_gateway_fqdn_prefix
+  backend_fqdns = var.app_gateway_backend_fqdns
+  tags          = var.tags
+}
+
 # NAT & VPN
 module "nat_gateway" {
   for_each = local.nat_gateway_settings == null ? {} : { default = local.nat_gateway_settings }

--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -24,10 +24,11 @@ subnets = {
   mgmt    = { address_prefixes = ["10.30.3.0/24"] }
 }
 
-# For module using subnet keys
-app_gateway_subnet_key  = "gateway"
-
-# For module using direct subnet id
+# -------------------------
+# Application Gateway
+# -------------------------
+app_gateway_subnet_key = "gateway"
+# Optional override when reusing an existing subnet
 app_gateway_subnet_id = "/subscriptions/930755b1-ef22-4721-a31a-1b6fbecf7da6/resourceGroups/rg-arbit-stage/providers/Microsoft.Network/virtualNetworks/vnet-arbit-stage/subnets/appgw"
 
 app_gateway_fqdn_prefix   = "agw-arbit-stage"

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -1,4 +1,49 @@
 # -------------------------
+# Application Gateway
+# -------------------------
+
+variable "app_gateway_subnet_key" {
+  description = "Key of the subnet reserved for the Application Gateway."
+  type        = string
+
+  validation {
+    condition     = try(trimspace(var.app_gateway_subnet_key), "") != ""
+    error_message = "app_gateway_subnet_key must not be empty."
+  }
+}
+
+variable "app_gateway_subnet_id" {
+  description = "Optional explicit subnet resource ID used for the Application Gateway when managed outside of this workspace."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.app_gateway_subnet_id == null || trimspace(var.app_gateway_subnet_id) != ""
+    error_message = "app_gateway_subnet_id cannot be an empty string; remove it instead."
+  }
+}
+
+variable "app_gateway_fqdn_prefix" {
+  description = "Domain name label applied to the Application Gateway public IP."
+  type        = string
+
+  validation {
+    condition     = try(trimspace(var.app_gateway_fqdn_prefix), "") != ""
+    error_message = "app_gateway_fqdn_prefix must not be empty."
+  }
+}
+
+variable "app_gateway_backend_fqdns" {
+  description = "List of backend hostnames routed through the Application Gateway."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.app_gateway_backend_fqdns) > 0
+    error_message = "At least one backend hostname must be provided for the Application Gateway."
+  }
+}
+
+# -------------------------
 # Connectivity
 # -------------------------
 


### PR DESCRIPTION
## Summary
- add the Application Gateway module to each environment stack and wire it to the existing network resources
- expose variables for the gateway FQDN prefix, backend hostnames, and subnet inputs so environments can configure them
- populate the dev, stage, and prod terraform.tfvars files with concrete gateway settings

## Testing
- Not run (terraform CLI is not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68c96a4dd9d08326bf22dcdbdd02af4e