### PR TITLE
Add Application Insights modules to environment configs

### DIFF
--- a/platform/infra/envs/dev/main.tf
+++ b/platform/infra/envs/dev/main.tf
@@ -4,6 +4,8 @@ locals {
   rg_name                      = "rg-${var.project_name}-${var.env_name}"
   kv_name                      = "kv-${var.project_name}-${var.env_name}"
   bastion_name                 = "bas-${var.project_name}-${var.env_name}"
+  log_name                     = var.log_analytics_workspace_name
+  appi_name                    = var.application_insights_name
   kv_private_endpoint_name     = "pep-${var.project_name}-${var.env_name}-kv"
   storage_private_endpoint_name = "pep-${var.project_name}-${var.env_name}-st"
 
@@ -73,6 +75,17 @@ module "resource_group" {
   name     = local.rg_name
   location = var.location
   tags     = var.tags
+}
+
+module "app_insights" {
+  source                           = "../../Azure/modules/app-insights"
+  resource_group_name              = module.resource_group.name
+  location                         = var.location
+  log_analytics_workspace_name     = local.log_name
+  application_insights_name        = local.appi_name
+  log_analytics_retention_in_days  = var.log_analytics_retention_in_days
+  log_analytics_daily_quota_gb     = var.log_analytics_daily_quota_gb
+  tags                             = var.tags
 }
 
 module "network" {

--- a/platform/infra/envs/dev/terraform.tfvars
+++ b/platform/infra/envs/dev/terraform.tfvars
@@ -14,6 +14,14 @@ tags = {
 }
 
 # -------------------------
+# Monitoring
+# -------------------------
+log_analytics_workspace_name    = "log-arbit-dev"
+application_insights_name       = "appi-arbit-dev"
+log_analytics_retention_in_days = 30
+log_analytics_daily_quota_gb    = -1
+
+# -------------------------
 # Networking
 # -------------------------
 vnet_address_space = ["10.20.0.0/16"]

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -22,6 +22,30 @@ variable "tags" {
   default     = {}
 }
 
+# -------------------------
+# Monitoring
+# -------------------------
+
+variable "log_analytics_workspace_name" {
+  description = "Name assigned to the Log Analytics workspace for this environment."
+  type        = string
+}
+
+variable "application_insights_name" {
+  description = "Name assigned to the Application Insights resource for this environment."
+  type        = string
+}
+
+variable "log_analytics_retention_in_days" {
+  description = "Number of days to retain data within the Log Analytics workspace."
+  type        = number
+}
+
+variable "log_analytics_daily_quota_gb" {
+  description = "Daily ingestion quota, in GB, for the Log Analytics workspace (-1 for unlimited)."
+  type        = number
+}
+
 variable "kv_cicd_principal_id" {
   description = "Optional object ID for the CI/CD principal that needs access to Key Vault secrets."
   type        = string

--- a/platform/infra/envs/prod/main.tf
+++ b/platform/infra/envs/prod/main.tf
@@ -3,8 +3,8 @@
 locals {
   rg_name          = "rg-${var.project_name}-${var.env_name}"
   kv_name          = "kv-${var.project_name}-${var.env_name}"
-  log_name         = "log-${var.project_name}-${var.env_name}"
-  appi_name        = "appi-${var.project_name}-${var.env_name}"
+  log_name         = var.log_analytics_workspace_name
+  appi_name        = var.application_insights_name
 
   acr_name         = lower(replace("acr${var.project_name}${var.env_name}", "-", ""))
   aks_name         = "aks-${var.project_name}-${var.env_name}-${var.location}"
@@ -87,6 +87,17 @@ module "resource_group" {
   name     = local.rg_name
   location = var.location
   tags     = var.tags
+}
+
+module "app_insights" {
+  source                           = "../../Azure/modules/app-insights"
+  resource_group_name              = module.resource_group.name
+  location                         = var.location
+  log_analytics_workspace_name     = local.log_name
+  application_insights_name        = local.appi_name
+  log_analytics_retention_in_days  = var.log_analytics_retention_in_days
+  log_analytics_daily_quota_gb     = var.log_analytics_daily_quota_gb
+  tags                             = var.tags
 }
 
 module "network" {

--- a/platform/infra/envs/prod/terraform.tfvars
+++ b/platform/infra/envs/prod/terraform.tfvars
@@ -14,6 +14,14 @@ tags = {
 }
 
 # -------------------------
+# Monitoring
+# -------------------------
+log_analytics_workspace_name    = "log-arbit-prod"
+application_insights_name       = "appi-arbit-prod"
+log_analytics_retention_in_days = 90
+log_analytics_daily_quota_gb    = -1
+
+# -------------------------
 # Networking
 # -------------------------
 vnet_address_space = ["10.40.0.0/16"]

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -1,4 +1,28 @@
 # -------------------------
+# Monitoring
+# -------------------------
+
+variable "log_analytics_workspace_name" {
+  description = "Name assigned to the Log Analytics workspace for this environment."
+  type        = string
+}
+
+variable "application_insights_name" {
+  description = "Name assigned to the Application Insights resource for this environment."
+  type        = string
+}
+
+variable "log_analytics_retention_in_days" {
+  description = "Number of days to retain data within the Log Analytics workspace."
+  type        = number
+}
+
+variable "log_analytics_daily_quota_gb" {
+  description = "Daily ingestion quota, in GB, for the Log Analytics workspace (-1 for unlimited)."
+  type        = number
+}
+
+# -------------------------
 # Connectivity
 # -------------------------
 

--- a/platform/infra/envs/stage/main.tf
+++ b/platform/infra/envs/stage/main.tf
@@ -3,8 +3,8 @@
 locals {
   rg_name          = "rg-${var.project_name}-${var.env_name}"
   kv_name          = "kv-${var.project_name}-${var.env_name}"
-  log_name         = "log-${var.project_name}-${var.env_name}"
-  appi_name        = "appi-${var.project_name}-${var.env_name}"
+  log_name         = var.log_analytics_workspace_name
+  appi_name        = var.application_insights_name
 
   acr_name         = lower(replace("acr${var.project_name}${var.env_name}", "-", ""))
   aks_name         = "aks-${var.project_name}-${var.env_name}-${var.location}"
@@ -87,6 +87,17 @@ module "resource_group" {
   name     = local.rg_name
   location = var.location
   tags     = var.tags
+}
+
+module "app_insights" {
+  source                           = "../../Azure/modules/app-insights"
+  resource_group_name              = module.resource_group.name
+  location                         = var.location
+  log_analytics_workspace_name     = local.log_name
+  application_insights_name        = local.appi_name
+  log_analytics_retention_in_days  = var.log_analytics_retention_in_days
+  log_analytics_daily_quota_gb     = var.log_analytics_daily_quota_gb
+  tags                             = var.tags
 }
 
 module "network" {

--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -14,6 +14,14 @@ tags = {
 }
 
 # -------------------------
+# Monitoring
+# -------------------------
+log_analytics_workspace_name    = "log-arbit-stage"
+application_insights_name       = "appi-arbit-stage"
+log_analytics_retention_in_days = 60
+log_analytics_daily_quota_gb    = -1
+
+# -------------------------
 # Networking
 # -------------------------
 vnet_address_space = ["10.30.0.0/16"]

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -1,4 +1,28 @@
 # -------------------------
+# Monitoring
+# -------------------------
+
+variable "log_analytics_workspace_name" {
+  description = "Name assigned to the Log Analytics workspace for this environment."
+  type        = string
+}
+
+variable "application_insights_name" {
+  description = "Name assigned to the Application Insights resource for this environment."
+  type        = string
+}
+
+variable "log_analytics_retention_in_days" {
+  description = "Number of days to retain data within the Log Analytics workspace."
+  type        = number
+}
+
+variable "log_analytics_daily_quota_gb" {
+  description = "Daily ingestion quota, in GB, for the Log Analytics workspace (-1 for unlimited)."
+  type        = number
+}
+
+# -------------------------
 # Connectivity
 # -------------------------
 


### PR DESCRIPTION
## Summary
- add the Application Insights module to each environment stack so monitoring resources are deployed alongside the resource group
- declare monitoring variables for workspace and application names plus retention controls
- provide environment-specific defaults for the monitoring settings through terraform.tfvars

## Testing
- terraform fmt platform/infra/envs/dev *(fails: `terraform` CLI not available in container)*


------
https://chatgpt.com/codex/tasks/task_e_68c96a51b7f48326a0e19f2d479b8480