### PR TITLE
Add SQL serverless module and configuration variables

### DIFF
--- a/platform/infra/envs/dev/main.tf
+++ b/platform/infra/envs/dev/main.tf
@@ -6,6 +6,8 @@ locals {
   bastion_name                 = "bas-${var.project_name}-${var.env_name}"
   kv_private_endpoint_name     = "pep-${var.project_name}-${var.env_name}-kv"
   storage_private_endpoint_name = "pep-${var.project_name}-${var.env_name}-st"
+  sql_server_name              = "sql-${var.project_name}-${var.env_name}"
+  sql_database_name            = var.sql_database_name != "" ? var.sql_database_name : "${var.project_name}-${var.env_name}"
 
   # NSG locals
   subnet_network_security_groups = {
@@ -156,6 +158,24 @@ module "kv" {
   network_acls                  = var.kv_network_acls
   private_endpoints             = local.kv_private_endpoints
   tags                          = var.tags
+}
+
+module "sql_serverless" {
+  source                         = "../../Azure/modules/sql-serverless"
+  server_name                    = local.sql_server_name
+  database_name                  = local.sql_database_name
+  resource_group_name            = module.resource_group.name
+  location                       = var.location
+  administrator_login            = var.sql_admin_login
+  administrator_password         = var.sql_admin_password
+  public_network_access_enabled  = var.sql_public_network_access
+  sku_name                       = var.sql_sku_name
+  max_size_gb                    = var.sql_max_size_gb
+  auto_pause_delay_in_minutes    = var.sql_auto_pause_delay
+  min_capacity                   = var.sql_min_capacity
+  max_capacity                   = var.sql_max_capacity
+  firewall_rules                 = var.sql_firewall_rules
+  tags                           = var.tags
 }
 
 resource "azurerm_role_assignment" "kv_cicd_secrets_user" {

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -308,3 +308,69 @@ variable "subnet_network_security_rules" {
   })))
   default = {}
 }
+
+# -------------------------
+# SQL Database
+# -------------------------
+variable "sql_database_name" {
+  description = "Optional override for the SQL database name. Defaults to <project>-<env> when blank."
+  type        = string
+  default     = ""
+}
+
+variable "sql_admin_login" {
+  description = "Administrator login for the SQL server. Provide securely via pipeline variables or Key Vault."
+  type        = string
+}
+
+variable "sql_admin_password" {
+  description = "Administrator password for the SQL server. Provide securely via pipeline variables or Key Vault."
+  type        = string
+  sensitive   = true
+}
+
+variable "sql_sku_name" {
+  description = "SKU name for the serverless SQL database (for example GP_S_Gen5_2)."
+  type        = string
+  default     = "GP_S_Gen5_2"
+}
+
+variable "sql_max_size_gb" {
+  description = "Maximum size of the SQL database in gigabytes."
+  type        = number
+  default     = 75
+}
+
+variable "sql_auto_pause_delay" {
+  description = "Number of minutes before the serverless database auto pauses. Use -1 to disable."
+  type        = number
+  default     = 60
+}
+
+variable "sql_min_capacity" {
+  description = "Minimum vCore capacity for the serverless database."
+  type        = number
+  default     = 0.5
+}
+
+variable "sql_max_capacity" {
+  description = "Maximum vCore capacity for the serverless database."
+  type        = number
+  default     = 4
+}
+
+variable "sql_public_network_access" {
+  description = "Whether public network access is enabled for the SQL server."
+  type        = bool
+  default     = true
+}
+
+variable "sql_firewall_rules" {
+  description = "List of firewall rules to apply to the SQL server."
+  type = list(object({
+    name             = string
+    start_ip_address = string
+    end_ip_address   = string
+  }))
+  default = []
+}

--- a/platform/infra/envs/prod/main.tf
+++ b/platform/infra/envs/prod/main.tf
@@ -158,6 +158,25 @@ module "storage_private_endpoint" {
   ] : []
 }
 
+# SQL
+module "sql_serverless" {
+  source                         = "../../Azure/modules/sql-serverless"
+  server_name                    = local.sql_server_name
+  database_name                  = local.sql_database_name
+  resource_group_name            = module.resource_group.name
+  location                       = var.location
+  administrator_login            = var.sql_admin_login
+  administrator_password         = var.sql_admin_password
+  public_network_access_enabled  = var.sql_public_network_access
+  sku_name                       = var.sql_sku_name
+  max_size_gb                    = var.sql_max_size_gb
+  auto_pause_delay_in_minutes    = var.sql_auto_pause_delay
+  min_capacity                   = var.sql_min_capacity
+  max_capacity                   = var.sql_max_capacity
+  firewall_rules                 = var.sql_firewall_rules
+  tags                           = var.tags
+}
+
 # NAT Gateway
 module "nat_gateway" {
   for_each = local.nat_gateway_settings == null ? {} : { default = local.nat_gateway_settings }

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -264,3 +264,69 @@ variable "storage_account_private_connection_resource_id" {
   type        = string
   default     = null
 }
+
+# -------------------------
+# SQL Database
+# -------------------------
+variable "sql_database_name" {
+  description = "Optional override for the SQL database name. Defaults to <project>-<env> when blank."
+  type        = string
+  default     = ""
+}
+
+variable "sql_admin_login" {
+  description = "Administrator login for the SQL server. Supply via secure pipeline variables or Key Vault."
+  type        = string
+}
+
+variable "sql_admin_password" {
+  description = "Administrator password for the SQL server. Supply via secure pipeline variables or Key Vault."
+  type        = string
+  sensitive   = true
+}
+
+variable "sql_sku_name" {
+  description = "SKU name for the serverless SQL database (for example GP_S_Gen5_2)."
+  type        = string
+  default     = "GP_S_Gen5_2"
+}
+
+variable "sql_max_size_gb" {
+  description = "Maximum size of the SQL database in gigabytes."
+  type        = number
+  default     = 75
+}
+
+variable "sql_auto_pause_delay" {
+  description = "Number of minutes before the serverless database auto pauses. Use -1 to disable."
+  type        = number
+  default     = 60
+}
+
+variable "sql_min_capacity" {
+  description = "Minimum vCore capacity for the serverless database."
+  type        = number
+  default     = 0.5
+}
+
+variable "sql_max_capacity" {
+  description = "Maximum vCore capacity for the serverless database."
+  type        = number
+  default     = 4
+}
+
+variable "sql_public_network_access" {
+  description = "Whether public network access is enabled for the SQL server."
+  type        = bool
+  default     = true
+}
+
+variable "sql_firewall_rules" {
+  description = "List of firewall rules to apply to the SQL server."
+  type = list(object({
+    name             = string
+    start_ip_address = string
+    end_ip_address   = string
+  }))
+  default = []
+}

--- a/platform/infra/envs/stage/main.tf
+++ b/platform/infra/envs/stage/main.tf
@@ -160,6 +160,25 @@ module "storage_private_endpoint" {
   ] : []
 }
 
+# SQL
+module "sql_serverless" {
+  source                         = "../../Azure/modules/sql-serverless"
+  server_name                    = local.sql_server_name
+  database_name                  = local.sql_database_name
+  resource_group_name            = module.resource_group.name
+  location                       = var.location
+  administrator_login            = var.sql_admin_login
+  administrator_password         = var.sql_admin_password
+  public_network_access_enabled  = var.sql_public_network_access
+  sku_name                       = var.sql_sku_name
+  max_size_gb                    = var.sql_max_size_gb
+  auto_pause_delay_in_minutes    = var.sql_auto_pause_delay
+  min_capacity                   = var.sql_min_capacity
+  max_capacity                   = var.sql_max_capacity
+  firewall_rules                 = var.sql_firewall_rules
+  tags                           = var.tags
+}
+
 # NAT & VPN
 module "nat_gateway" {
   for_each = local.nat_gateway_settings == null ? {} : { default = local.nat_gateway_settings }

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -264,3 +264,69 @@ variable "storage_account_private_connection_resource_id" {
   type        = string
   default     = null
 }
+
+# -------------------------
+# SQL Database
+# -------------------------
+variable "sql_database_name" {
+  description = "Optional override for the SQL database name. Defaults to <project>-<env> when blank."
+  type        = string
+  default     = ""
+}
+
+variable "sql_admin_login" {
+  description = "Administrator login for the SQL server. Supply via secure pipeline variables or Key Vault."
+  type        = string
+}
+
+variable "sql_admin_password" {
+  description = "Administrator password for the SQL server. Supply via secure pipeline variables or Key Vault."
+  type        = string
+  sensitive   = true
+}
+
+variable "sql_sku_name" {
+  description = "SKU name for the serverless SQL database (for example GP_S_Gen5_2)."
+  type        = string
+  default     = "GP_S_Gen5_2"
+}
+
+variable "sql_max_size_gb" {
+  description = "Maximum size of the SQL database in gigabytes."
+  type        = number
+  default     = 75
+}
+
+variable "sql_auto_pause_delay" {
+  description = "Number of minutes before the serverless database auto pauses. Use -1 to disable."
+  type        = number
+  default     = 60
+}
+
+variable "sql_min_capacity" {
+  description = "Minimum vCore capacity for the serverless database."
+  type        = number
+  default     = 0.5
+}
+
+variable "sql_max_capacity" {
+  description = "Maximum vCore capacity for the serverless database."
+  type        = number
+  default     = 4
+}
+
+variable "sql_public_network_access" {
+  description = "Whether public network access is enabled for the SQL server."
+  type        = bool
+  default     = true
+}
+
+variable "sql_firewall_rules" {
+  description = "List of firewall rules to apply to the SQL server."
+  type = list(object({
+    name             = string
+    start_ip_address = string
+    end_ip_address   = string
+  }))
+  default = []
+}


### PR DESCRIPTION
## Summary
- add the sql_serverless module to the dev, stage, and prod environment compositions
- define SQL configuration inputs (SKU, sizing, auto-pause, firewall rules) plus admin credentials for each environment
- rely on pipeline / Key Vault secrets for the SQL administrator login and password to keep credentials out of source control

## Testing
- terraform fmt *(fails: terraform binary unavailable in container and hashicorp download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68c96a5a8518832694b8ce4cff8ddeda