### PR TITLE
Manage stage/prod key vaults

### DIFF
--- a/platform/infra/envs/prod/main.tf
+++ b/platform/infra/envs/prod/main.tf
@@ -76,6 +76,9 @@ locals {
 
   # Private Endpoint lookups
   kv_private_endpoint_subnet_id = var.enable_kv_private_endpoint && var.kv_private_endpoint_subnet_key != null && var.kv_private_endpoint_subnet_key != "" ? lookup(module.network.subnet_ids, var.kv_private_endpoint_subnet_key, null) : null
+  kv_private_endpoints = local.kv_private_endpoint_subnet_id != null ? [
+    { subnet_id = local.kv_private_endpoint_subnet_id }
+  ] : []
   storage_private_endpoint_subnet_id = var.enable_storage_private_endpoint && var.storage_private_endpoint_subnet_key != null && var.storage_private_endpoint_subnet_key != "" ? lookup(module.network.subnet_ids, var.storage_private_endpoint_subnet_key, null) : null
 }
 
@@ -111,9 +114,21 @@ module "network_security_groups" {
   subnet_ids          = toset([module.network.subnet_ids[each.key]])
 }
 
+# Key Vault
+module "kv" {
+  source                        = "../../Azure/modules/key-vault"
+  name                          = local.kv_name
+  resource_group_name           = module.resource_group.name
+  location                      = var.location
+  public_network_access_enabled = var.kv_public_network_access
+  network_acls                  = var.kv_network_acls
+  private_endpoints             = local.kv_private_endpoints
+  tags                          = var.tags
+}
+
 # Private Endpoints
 module "kv_private_endpoint" {
-  count = var.enable_kv_private_endpoint && local.kv_private_endpoint_subnet_id != null && var.kv_private_endpoint_resource_id != null ? 1 : 0
+  count = var.enable_kv_private_endpoint && local.kv_private_endpoint_subnet_id != null && coalesce(var.kv_private_endpoint_resource_id, module.kv.id) != null ? 1 : 0
   source              = "../../Azure/modules/private-endpoint"
   name                = local.kv_private_endpoint_name
   resource_group_name = module.resource_group.name
@@ -123,7 +138,7 @@ module "kv_private_endpoint" {
 
   private_service_connection = {
     name                           = "kv-${var.project_name}-${var.env_name}"
-    private_connection_resource_id = var.kv_private_endpoint_resource_id
+    private_connection_resource_id = coalesce(var.kv_private_endpoint_resource_id, module.kv.id)
     subresource_names              = ["vault"]
   }
 

--- a/platform/infra/envs/prod/terraform.tfvars
+++ b/platform/infra/envs/prod/terraform.tfvars
@@ -24,8 +24,23 @@ subnets = {
   mgmt    = { address_prefixes = ["10.40.3.0/24"] }
 }
 
-# For module using subnet keys
-app_gateway_subnet_key  = "gateway"
+# Subnet references for optional modules
+app_gateway_subnet_key              = "gateway"
+kv_private_endpoint_subnet_key      = "data"
+storage_private_endpoint_subnet_key = "data"
+
+# Key Vault configuration
+kv_public_network_access       = true
+kv_network_acls                = null
+enable_kv_private_endpoint     = false
+kv_private_dns_zone_ids        = []
+kv_private_endpoint_resource_id = null
+
+# Storage private endpoint configuration
+enable_storage_private_endpoint                = false
+storage_private_dns_zone_ids                   = []
+storage_private_endpoint_subresource_names     = ["blob"]
+storage_account_private_connection_resource_id = null
 
 # For module using direct subnet id
 app_gateway_subnet_id = "/subscriptions/930755b1-ef22-4721-a31a-1b6fbecf7da6/resourceGroups/rg-arbit-prod/providers/Microsoft.Network/virtualNetworks/vnet-arbit-prod/subnets/appgw"

--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -24,8 +24,23 @@ subnets = {
   mgmt    = { address_prefixes = ["10.30.3.0/24"] }
 }
 
-# For module using subnet keys
-app_gateway_subnet_key  = "gateway"
+# Subnet references for optional modules
+app_gateway_subnet_key              = "gateway"
+kv_private_endpoint_subnet_key      = "data"
+storage_private_endpoint_subnet_key = "data"
+
+# Key Vault configuration
+kv_public_network_access       = true
+kv_network_acls                = null
+enable_kv_private_endpoint     = false
+kv_private_dns_zone_ids        = []
+kv_private_endpoint_resource_id = null
+
+# Storage private endpoint configuration
+enable_storage_private_endpoint                = false
+storage_private_dns_zone_ids                   = []
+storage_private_endpoint_subresource_names     = ["blob"]
+storage_account_private_connection_resource_id = null
 
 # For module using direct subnet id
 app_gateway_subnet_id = "/subscriptions/930755b1-ef22-4721-a31a-1b6fbecf7da6/resourceGroups/rg-arbit-stage/providers/Microsoft.Network/virtualNetworks/vnet-arbit-stage/subnets/appgw"


### PR DESCRIPTION
## Summary
- provision the stage and prod Key Vaults with the shared module and reuse their IDs when wiring private endpoints
- surface the Key Vault and storage private endpoint settings in the stage and prod terraform.tfvars files for easier environment configuration

## Testing
- terraform fmt *(fails: terraform binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c96a6c26688326b6831e900f7ec96f