### PR TITLE
Add function app modules and configuration for all environments

### DIFF
--- a/platform/infra/envs/dev/main.tf
+++ b/platform/infra/envs/dev/main.tf
@@ -4,6 +4,10 @@ locals {
   rg_name                      = "rg-${var.project_name}-${var.env_name}"
   kv_name                      = "kv-${var.project_name}-${var.env_name}"
   bastion_name                 = "bas-${var.project_name}-${var.env_name}"
+  func_external_plan           = var.external_function_plan_name
+  func_external_name           = var.external_function_name
+  func_cron_plan               = var.cron_function_plan_name
+  func_cron_name               = var.cron_function_name
   kv_private_endpoint_name     = "pep-${var.project_name}-${var.env_name}-kv"
   storage_private_endpoint_name = "pep-${var.project_name}-${var.env_name}-st"
 
@@ -209,6 +213,44 @@ module "storage_private_endpoint" {
       private_dns_zone_ids = var.storage_private_dns_zone_ids
     }
   ] : []
+}
+
+# -------------------------
+# Function Apps
+# -------------------------
+
+module "cron_function_app" {
+  source              = "../../Azure/modules/linux-function-app"
+  name                = local.func_cron_name
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  plan_name           = local.func_cron_plan
+  plan_sku            = var.cron_function_plan_sku
+  runtime_stack       = var.cron_function_runtime_stack
+  runtime_version     = var.cron_function_runtime_version
+  storage_account_name = var.cron_function_storage_account_name
+
+  application_insights_connection_string = var.cron_function_application_insights_connection_string
+  log_analytics_workspace_id              = var.cron_function_log_analytics_workspace_id
+  app_settings                            = var.cron_function_app_settings
+  tags                                    = var.tags
+}
+
+module "external_function_app" {
+  source              = "../../Azure/modules/linux-function-app"
+  name                = local.func_external_name
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  plan_name           = local.func_external_plan
+  plan_sku            = var.external_function_plan_sku
+  runtime_stack       = var.external_function_runtime_stack
+  runtime_version     = var.external_function_runtime_version
+  storage_account_name = var.external_function_storage_account_name
+
+  application_insights_connection_string = var.external_function_application_insights_connection_string
+  log_analytics_workspace_id              = var.external_function_log_analytics_workspace_id
+  app_settings                            = var.external_function_app_settings
+  tags                                    = var.tags
 }
 
 # -------------------------

--- a/platform/infra/envs/dev/terraform.tfvars
+++ b/platform/infra/envs/dev/terraform.tfvars
@@ -30,3 +30,22 @@ kv_private_endpoint_subnet_key      = "data"
 storage_private_endpoint_subnet_key = "data"
 
 kv_public_network_access = true
+
+# -------------------------
+# Function Apps
+# -------------------------
+cron_function_name       = "func-cron-dev"
+cron_function_plan_name  = "asp-cron-dev-eastus"
+cron_function_plan_sku   = "Y1"
+cron_function_runtime_stack = "dotnet"
+# App settings are supplied via pipeline secrets / Key Vault references.
+cron_function_app_settings = {}
+cron_function_application_insights_connection_string = ""
+
+external_function_name       = "func-external-dev"
+external_function_plan_name  = "asp-external-dev-eastus"
+external_function_plan_sku   = "Y1"
+external_function_runtime_stack = "dotnet"
+# App settings are supplied via pipeline secrets / Key Vault references.
+external_function_app_settings = {}
+external_function_application_insights_connection_string = ""

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -308,3 +308,131 @@ variable "subnet_network_security_rules" {
   })))
   default = {}
 }
+
+# -------------------------
+# Function Apps
+# -------------------------
+
+variable "cron_function_name" {
+  description = "Name of the cron Function App."
+  type        = string
+}
+
+variable "cron_function_plan_name" {
+  description = "Name of the App Service plan used by the cron Function App."
+  type        = string
+}
+
+variable "cron_function_plan_sku" {
+  description = "SKU for the cron Function App service plan."
+  type        = string
+  default     = "Y1"
+}
+
+variable "cron_function_runtime_stack" {
+  description = "Worker runtime stack for the cron Function App."
+  type        = string
+  default     = "dotnet"
+
+  validation {
+    condition     = contains(["dotnet", "node", "python"], lower(trimspace(var.cron_function_runtime_stack)))
+    error_message = "cron_function_runtime_stack must be one of: dotnet, node, python."
+  }
+}
+
+variable "cron_function_runtime_version" {
+  description = "Optional runtime version for the cron Function App."
+  type        = string
+  default     = ""
+}
+
+variable "cron_function_app_settings" {
+  description = "Additional application settings for the cron Function App."
+  type        = map(string)
+  default     = {}
+}
+
+variable "cron_function_application_insights_connection_string" {
+  description = "Application Insights connection string for the cron Function App."
+  type        = string
+  default     = ""
+}
+
+variable "cron_function_log_analytics_workspace_id" {
+  description = "Log Analytics workspace ID used for cron Function App diagnostics."
+  type        = string
+  default     = null
+}
+
+variable "cron_function_storage_account_name" {
+  description = "Optional storage account name backing the cron Function App."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.cron_function_storage_account_name == "" ? true : can(regex("^[a-z0-9]{3,24}$", var.cron_function_storage_account_name))
+    error_message = "cron_function_storage_account_name must be empty or contain 3-24 lowercase letters and numbers."
+  }
+}
+
+variable "external_function_name" {
+  description = "Name of the external Function App."
+  type        = string
+}
+
+variable "external_function_plan_name" {
+  description = "Name of the App Service plan used by the external Function App."
+  type        = string
+}
+
+variable "external_function_plan_sku" {
+  description = "SKU for the external Function App service plan."
+  type        = string
+  default     = "Y1"
+}
+
+variable "external_function_runtime_stack" {
+  description = "Worker runtime stack for the external Function App."
+  type        = string
+  default     = "dotnet"
+
+  validation {
+    condition     = contains(["dotnet", "node", "python"], lower(trimspace(var.external_function_runtime_stack)))
+    error_message = "external_function_runtime_stack must be one of: dotnet, node, python."
+  }
+}
+
+variable "external_function_runtime_version" {
+  description = "Optional runtime version for the external Function App."
+  type        = string
+  default     = ""
+}
+
+variable "external_function_app_settings" {
+  description = "Additional application settings for the external Function App."
+  type        = map(string)
+  default     = {}
+}
+
+variable "external_function_application_insights_connection_string" {
+  description = "Application Insights connection string for the external Function App."
+  type        = string
+  default     = ""
+}
+
+variable "external_function_log_analytics_workspace_id" {
+  description = "Log Analytics workspace ID used for external Function App diagnostics."
+  type        = string
+  default     = null
+}
+
+variable "external_function_storage_account_name" {
+  description = "Optional storage account name backing the external Function App."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.external_function_storage_account_name == "" ? true : can(regex("^[a-z0-9]{3,24}$", var.external_function_storage_account_name))
+    error_message = "external_function_storage_account_name must be empty or contain 3-24 lowercase letters and numbers."
+  }
+}

--- a/platform/infra/envs/prod/main.tf
+++ b/platform/infra/envs/prod/main.tf
@@ -16,10 +16,10 @@ locals {
   arbitration_plan = "asp-${var.project_name}-arb-${var.env_name}-${var.location}"
   arbitration_name = "app-${var.project_name}-arb-${var.env_name}"
 
-  func_external_plan = "asp-external-${var.env_name}-${var.location}"
-  func_external_name = "func-external-${var.env_name}"
-  func_cron_plan     = "asp-cron-${var.env_name}-${var.location}"
-  func_cron_name     = "func-cron-${var.env_name}"
+  func_external_plan = var.external_function_plan_name
+  func_external_name = var.external_function_name
+  func_cron_plan     = var.cron_function_plan_name
+  func_cron_name     = var.cron_function_name
 
   sql_server_name   = "sql-${var.project_name}-${var.env_name}"
   sql_database_name = var.sql_database_name != "" ? var.sql_database_name : "${var.project_name}-${var.env_name}"
@@ -156,6 +156,44 @@ module "storage_private_endpoint" {
       private_dns_zone_ids = var.storage_private_dns_zone_ids
     }
   ] : []
+}
+
+# -------------------------
+# Function Apps
+# -------------------------
+
+module "cron_function_app" {
+  source              = "../../Azure/modules/linux-function-app"
+  name                = local.func_cron_name
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  plan_name           = local.func_cron_plan
+  plan_sku            = var.cron_function_plan_sku
+  runtime_stack       = var.cron_function_runtime_stack
+  runtime_version     = var.cron_function_runtime_version
+  storage_account_name = var.cron_function_storage_account_name
+
+  application_insights_connection_string = var.cron_function_application_insights_connection_string
+  log_analytics_workspace_id              = var.cron_function_log_analytics_workspace_id
+  app_settings                            = var.cron_function_app_settings
+  tags                                    = var.tags
+}
+
+module "external_function_app" {
+  source              = "../../Azure/modules/linux-function-app"
+  name                = local.func_external_name
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  plan_name           = local.func_external_plan
+  plan_sku            = var.external_function_plan_sku
+  runtime_stack       = var.external_function_runtime_stack
+  runtime_version     = var.external_function_runtime_version
+  storage_account_name = var.external_function_storage_account_name
+
+  application_insights_connection_string = var.external_function_application_insights_connection_string
+  log_analytics_workspace_id              = var.external_function_log_analytics_workspace_id
+  app_settings                            = var.external_function_app_settings
+  tags                                    = var.tags
 }
 
 # NAT Gateway

--- a/platform/infra/envs/prod/terraform.tfvars
+++ b/platform/infra/envs/prod/terraform.tfvars
@@ -79,6 +79,25 @@ arbitration_app_settings = {
 }
 
 # -------------------------
+# Function Apps
+# -------------------------
+cron_function_name          = "func-cron-prod"
+cron_function_plan_name     = "asp-cron-prod-eastus2"
+cron_function_plan_sku      = "Y1"
+cron_function_runtime_stack = "dotnet"
+# Additional configuration is sourced from pipeline secrets / Key Vault references.
+cron_function_app_settings = {}
+cron_function_application_insights_connection_string = ""
+
+external_function_name          = "func-external-prod"
+external_function_plan_name     = "asp-external-prod-eastus2"
+external_function_plan_sku      = "Y1"
+external_function_runtime_stack = "dotnet"
+# Additional configuration is sourced from pipeline secrets / Key Vault references.
+external_function_app_settings = {}
+external_function_application_insights_connection_string = ""
+
+# -------------------------
 # SQL Database
 # -------------------------
 # Support both sql_database_name and sql_db_name for different modules

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -264,3 +264,131 @@ variable "storage_account_private_connection_resource_id" {
   type        = string
   default     = null
 }
+
+# -------------------------
+# Function Apps
+# -------------------------
+
+variable "cron_function_name" {
+  description = "Name of the cron Function App."
+  type        = string
+}
+
+variable "cron_function_plan_name" {
+  description = "Name of the App Service plan used by the cron Function App."
+  type        = string
+}
+
+variable "cron_function_plan_sku" {
+  description = "SKU for the cron Function App service plan."
+  type        = string
+  default     = "Y1"
+}
+
+variable "cron_function_runtime_stack" {
+  description = "Worker runtime stack for the cron Function App."
+  type        = string
+  default     = "dotnet"
+
+  validation {
+    condition     = contains(["dotnet", "node", "python"], lower(trimspace(var.cron_function_runtime_stack)))
+    error_message = "cron_function_runtime_stack must be one of: dotnet, node, python."
+  }
+}
+
+variable "cron_function_runtime_version" {
+  description = "Optional runtime version for the cron Function App."
+  type        = string
+  default     = ""
+}
+
+variable "cron_function_app_settings" {
+  description = "Additional application settings for the cron Function App."
+  type        = map(string)
+  default     = {}
+}
+
+variable "cron_function_application_insights_connection_string" {
+  description = "Application Insights connection string for the cron Function App."
+  type        = string
+  default     = ""
+}
+
+variable "cron_function_log_analytics_workspace_id" {
+  description = "Log Analytics workspace ID used for cron Function App diagnostics."
+  type        = string
+  default     = null
+}
+
+variable "cron_function_storage_account_name" {
+  description = "Optional storage account name backing the cron Function App."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.cron_function_storage_account_name == "" ? true : can(regex("^[a-z0-9]{3,24}$", var.cron_function_storage_account_name))
+    error_message = "cron_function_storage_account_name must be empty or contain 3-24 lowercase letters and numbers."
+  }
+}
+
+variable "external_function_name" {
+  description = "Name of the external Function App."
+  type        = string
+}
+
+variable "external_function_plan_name" {
+  description = "Name of the App Service plan used by the external Function App."
+  type        = string
+}
+
+variable "external_function_plan_sku" {
+  description = "SKU for the external Function App service plan."
+  type        = string
+  default     = "Y1"
+}
+
+variable "external_function_runtime_stack" {
+  description = "Worker runtime stack for the external Function App."
+  type        = string
+  default     = "dotnet"
+
+  validation {
+    condition     = contains(["dotnet", "node", "python"], lower(trimspace(var.external_function_runtime_stack)))
+    error_message = "external_function_runtime_stack must be one of: dotnet, node, python."
+  }
+}
+
+variable "external_function_runtime_version" {
+  description = "Optional runtime version for the external Function App."
+  type        = string
+  default     = ""
+}
+
+variable "external_function_app_settings" {
+  description = "Additional application settings for the external Function App."
+  type        = map(string)
+  default     = {}
+}
+
+variable "external_function_application_insights_connection_string" {
+  description = "Application Insights connection string for the external Function App."
+  type        = string
+  default     = ""
+}
+
+variable "external_function_log_analytics_workspace_id" {
+  description = "Log Analytics workspace ID used for external Function App diagnostics."
+  type        = string
+  default     = null
+}
+
+variable "external_function_storage_account_name" {
+  description = "Optional storage account name backing the external Function App."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.external_function_storage_account_name == "" ? true : can(regex("^[a-z0-9]{3,24}$", var.external_function_storage_account_name))
+    error_message = "external_function_storage_account_name must be empty or contain 3-24 lowercase letters and numbers."
+  }
+}

--- a/platform/infra/envs/stage/main.tf
+++ b/platform/infra/envs/stage/main.tf
@@ -16,10 +16,10 @@ locals {
   arbitration_plan = "asp-${var.project_name}-arb-${var.env_name}-${var.location}"
   arbitration_name = "app-${var.project_name}-arb-${var.env_name}"
 
-  func_external_plan = "asp-external-${var.env_name}-${var.location}"
-  func_external_name = "func-external-${var.env_name}"
-  func_cron_plan     = "asp-cron-${var.env_name}-${var.location}"
-  func_cron_name     = "func-cron-${var.env_name}"
+  func_external_plan = var.external_function_plan_name
+  func_external_name = var.external_function_name
+  func_cron_plan     = var.cron_function_plan_name
+  func_cron_name     = var.cron_function_name
 
   sql_server_name   = "sql-${var.project_name}-${var.env_name}"
   sql_database_name = var.sql_database_name != "" ? var.sql_database_name : "${var.project_name}-${var.env_name}"
@@ -158,6 +158,44 @@ module "storage_private_endpoint" {
       private_dns_zone_ids = var.storage_private_dns_zone_ids
     }
   ] : []
+}
+
+# -------------------------
+# Function Apps
+# -------------------------
+
+module "cron_function_app" {
+  source              = "../../Azure/modules/linux-function-app"
+  name                = local.func_cron_name
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  plan_name           = local.func_cron_plan
+  plan_sku            = var.cron_function_plan_sku
+  runtime_stack       = var.cron_function_runtime_stack
+  runtime_version     = var.cron_function_runtime_version
+  storage_account_name = var.cron_function_storage_account_name
+
+  application_insights_connection_string = var.cron_function_application_insights_connection_string
+  log_analytics_workspace_id              = var.cron_function_log_analytics_workspace_id
+  app_settings                            = var.cron_function_app_settings
+  tags                                    = var.tags
+}
+
+module "external_function_app" {
+  source              = "../../Azure/modules/linux-function-app"
+  name                = local.func_external_name
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  plan_name           = local.func_external_plan
+  plan_sku            = var.external_function_plan_sku
+  runtime_stack       = var.external_function_runtime_stack
+  runtime_version     = var.external_function_runtime_version
+  storage_account_name = var.external_function_storage_account_name
+
+  application_insights_connection_string = var.external_function_application_insights_connection_string
+  log_analytics_workspace_id              = var.external_function_log_analytics_workspace_id
+  app_settings                            = var.external_function_app_settings
+  tags                                    = var.tags
 }
 
 # NAT & VPN

--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -79,6 +79,25 @@ arbitration_app_settings = {
 }
 
 # -------------------------
+# Function Apps
+# -------------------------
+cron_function_name          = "func-cron-stage"
+cron_function_plan_name     = "asp-cron-stage-eastus"
+cron_function_plan_sku      = "Y1"
+cron_function_runtime_stack = "dotnet"
+# Additional configuration is sourced from pipeline secrets / Key Vault references.
+cron_function_app_settings = {}
+cron_function_application_insights_connection_string = ""
+
+external_function_name          = "func-external-stage"
+external_function_plan_name     = "asp-external-stage-eastus"
+external_function_plan_sku      = "Y1"
+external_function_runtime_stack = "dotnet"
+# Additional configuration is sourced from pipeline secrets / Key Vault references.
+external_function_app_settings = {}
+external_function_application_insights_connection_string = ""
+
+# -------------------------
 # SQL Database
 # -------------------------
 # Support both sql_database_name and sql_db_name for different modules

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -264,3 +264,131 @@ variable "storage_account_private_connection_resource_id" {
   type        = string
   default     = null
 }
+
+# -------------------------
+# Function Apps
+# -------------------------
+
+variable "cron_function_name" {
+  description = "Name of the cron Function App."
+  type        = string
+}
+
+variable "cron_function_plan_name" {
+  description = "Name of the App Service plan used by the cron Function App."
+  type        = string
+}
+
+variable "cron_function_plan_sku" {
+  description = "SKU for the cron Function App service plan."
+  type        = string
+  default     = "Y1"
+}
+
+variable "cron_function_runtime_stack" {
+  description = "Worker runtime stack for the cron Function App."
+  type        = string
+  default     = "dotnet"
+
+  validation {
+    condition     = contains(["dotnet", "node", "python"], lower(trimspace(var.cron_function_runtime_stack)))
+    error_message = "cron_function_runtime_stack must be one of: dotnet, node, python."
+  }
+}
+
+variable "cron_function_runtime_version" {
+  description = "Optional runtime version for the cron Function App."
+  type        = string
+  default     = ""
+}
+
+variable "cron_function_app_settings" {
+  description = "Additional application settings for the cron Function App."
+  type        = map(string)
+  default     = {}
+}
+
+variable "cron_function_application_insights_connection_string" {
+  description = "Application Insights connection string for the cron Function App."
+  type        = string
+  default     = ""
+}
+
+variable "cron_function_log_analytics_workspace_id" {
+  description = "Log Analytics workspace ID used for cron Function App diagnostics."
+  type        = string
+  default     = null
+}
+
+variable "cron_function_storage_account_name" {
+  description = "Optional storage account name backing the cron Function App."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.cron_function_storage_account_name == "" ? true : can(regex("^[a-z0-9]{3,24}$", var.cron_function_storage_account_name))
+    error_message = "cron_function_storage_account_name must be empty or contain 3-24 lowercase letters and numbers."
+  }
+}
+
+variable "external_function_name" {
+  description = "Name of the external Function App."
+  type        = string
+}
+
+variable "external_function_plan_name" {
+  description = "Name of the App Service plan used by the external Function App."
+  type        = string
+}
+
+variable "external_function_plan_sku" {
+  description = "SKU for the external Function App service plan."
+  type        = string
+  default     = "Y1"
+}
+
+variable "external_function_runtime_stack" {
+  description = "Worker runtime stack for the external Function App."
+  type        = string
+  default     = "dotnet"
+
+  validation {
+    condition     = contains(["dotnet", "node", "python"], lower(trimspace(var.external_function_runtime_stack)))
+    error_message = "external_function_runtime_stack must be one of: dotnet, node, python."
+  }
+}
+
+variable "external_function_runtime_version" {
+  description = "Optional runtime version for the external Function App."
+  type        = string
+  default     = ""
+}
+
+variable "external_function_app_settings" {
+  description = "Additional application settings for the external Function App."
+  type        = map(string)
+  default     = {}
+}
+
+variable "external_function_application_insights_connection_string" {
+  description = "Application Insights connection string for the external Function App."
+  type        = string
+  default     = ""
+}
+
+variable "external_function_log_analytics_workspace_id" {
+  description = "Log Analytics workspace ID used for external Function App diagnostics."
+  type        = string
+  default     = null
+}
+
+variable "external_function_storage_account_name" {
+  description = "Optional storage account name backing the external Function App."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.external_function_storage_account_name == "" ? true : can(regex("^[a-z0-9]{3,24}$", var.external_function_storage_account_name))
+    error_message = "external_function_storage_account_name must be empty or contain 3-24 lowercase letters and numbers."
+  }
+}


### PR DESCRIPTION
## Summary
- add linux function app modules for cron and external functions to each environment configuration
- declare function specific variables for app service plans, runtimes, diagnostics, and settings
- populate terraform.tfvars with plan, runtime, and placeholder application settings for both functions across environments

## Testing
- not run (terraform CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c96a4c497c8326bd34ee992b33b22b