### PR TITLE
Add App Service modules to environment configurations

### DIFF
--- a/platform/infra/Azure/modules/app-service-web/main.tf
+++ b/platform/infra/Azure/modules/app-service-web/main.tf
@@ -21,6 +21,16 @@ resource "azurerm_linux_web_app" "app" {
     "APPINSIGHTS_CONNECTION_STRING" = var.app_insights_connection_string
     "WEBSITE_RUN_FROM_PACKAGE"      = "1"
   }, var.app_settings)
+
+  dynamic "connection_string" {
+    for_each = var.connection_strings
+    content {
+      name  = connection_string.key
+      type  = connection_string.value.type
+      value = connection_string.value.value
+    }
+  }
+
   tags = var.tags
 }
 

--- a/platform/infra/Azure/modules/app-service-web/variables.tf
+++ b/platform/infra/Azure/modules/app-service-web/variables.tf
@@ -22,6 +22,14 @@ variable "app_settings" {
   default = {}
 }
 
+variable "connection_strings" {
+  type = map(object({
+    type  = string
+    value = string
+  }))
+  default = {}
+}
+
 variable "tags" {
   type    = map(string)
   default = {}

--- a/platform/infra/envs/dev/main.tf
+++ b/platform/infra/envs/dev/main.tf
@@ -6,6 +6,10 @@ locals {
   bastion_name                 = "bas-${var.project_name}-${var.env_name}"
   kv_private_endpoint_name     = "pep-${var.project_name}-${var.env_name}-kv"
   storage_private_endpoint_name = "pep-${var.project_name}-${var.env_name}-st"
+  app_service_plan_name        = "asp-${var.project_name}-web-${var.env_name}-${var.location}"
+  app_service_name             = "app-${var.project_name}-web-${var.env_name}"
+  arbitration_plan_name        = "asp-${var.project_name}-arb-${var.env_name}-${var.location}"
+  arbitration_app_name         = "app-${var.project_name}-arb-${var.env_name}"
 
   # NSG locals
   subnet_network_security_groups = {
@@ -209,6 +213,44 @@ module "storage_private_endpoint" {
       private_dns_zone_ids = var.storage_private_dns_zone_ids
     }
   ] : []
+}
+
+# App Services
+module "app_service_web" {
+  source = "../../Azure/modules/app-service-web"
+
+  name                = local.app_service_name
+  plan_name           = local.app_service_plan_name
+  plan_sku            = var.app_service_plan_sku
+  resource_group_name = module.resource_group.name
+  location            = var.location
+
+  dotnet_version                 = var.app_service_dotnet_version
+  app_insights_connection_string = var.app_service_app_insights_connection_string
+  log_analytics_workspace_id     = var.app_service_log_analytics_workspace_id
+  app_settings                   = var.app_service_app_settings
+  connection_strings             = var.app_service_connection_strings
+  tags                           = var.tags
+}
+
+module "app_service_arbitration" {
+  count = var.enable_arbitration_app_service ? 1 : 0
+  source = "../../Azure/modules/app-service-arbitration"
+
+  name                = local.arbitration_app_name
+  plan_name           = local.arbitration_plan_name
+  plan_sku            = var.arbitration_app_plan_sku != null && trimspace(var.arbitration_app_plan_sku) != "" ? var.arbitration_app_plan_sku : var.app_service_plan_sku
+  resource_group_name = module.resource_group.name
+  location            = var.location
+
+  runtime_stack                  = var.arbitration_runtime_stack
+  runtime_version                = var.arbitration_runtime_version
+  app_insights_connection_string = var.arbitration_app_insights_connection_string != null && trimspace(var.arbitration_app_insights_connection_string) != "" ? var.arbitration_app_insights_connection_string : var.app_service_app_insights_connection_string
+  log_analytics_workspace_id     = var.arbitration_log_analytics_workspace_id != null && trimspace(var.arbitration_log_analytics_workspace_id) != "" ? var.arbitration_log_analytics_workspace_id : var.app_service_log_analytics_workspace_id
+  connection_strings             = var.arbitration_connection_strings
+  app_settings                   = var.arbitration_app_settings
+  run_from_package               = var.arbitration_run_from_package
+  tags                           = var.tags
 }
 
 # -------------------------

--- a/platform/infra/envs/dev/terraform.tfvars
+++ b/platform/infra/envs/dev/terraform.tfvars
@@ -30,3 +30,26 @@ kv_private_endpoint_subnet_key      = "data"
 storage_private_endpoint_subnet_key = "data"
 
 kv_public_network_access = true
+
+# -------------------------
+# App Service
+# -------------------------
+app_service_plan_sku                     = "B1"
+app_service_app_insights_connection_string = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-dev.vault.azure.net/secrets/app-service-appinsights-connection-string)"
+app_service_app_settings                 = {}
+app_service_connection_strings = {
+  PrimaryDatabase = {
+    type  = "SQLAzure"
+    value = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-dev.vault.azure.net/secrets/app-service-primary-database-connection)"
+  }
+}
+
+# -------------------------
+# Arbitration App
+# -------------------------
+enable_arbitration_app_service          = true
+arbitration_app_settings = {
+  "Storage__Connection" = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-dev.vault.azure.net/secrets/arbitration-storage-connection)"
+  "Storage__Container"  = "arbitration-calculator"
+}
+arbitration_app_insights_connection_string = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-dev.vault.azure.net/secrets/arbitration-appinsights-connection-string)"

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -257,6 +257,115 @@ variable "storage_account_private_connection_resource_id" {
 }
 
 # -------------------------
+# App Services
+# -------------------------
+
+variable "app_service_plan_sku" {
+  description = "SKU for the App Service plan hosting the primary web application."
+  type        = string
+  default     = "B1"
+}
+
+variable "app_service_dotnet_version" {
+  description = ".NET runtime version for the primary web application."
+  type        = string
+  default     = "8.0"
+}
+
+variable "app_service_app_insights_connection_string" {
+  description = "Application Insights connection string injected into the primary web app."
+  type        = string
+
+  validation {
+    condition     = try(trimspace(var.app_service_app_insights_connection_string), "") != ""
+    error_message = "app_service_app_insights_connection_string must be provided when deploying the web app."
+  }
+}
+
+variable "app_service_log_analytics_workspace_id" {
+  description = "Optional Log Analytics workspace resource ID for App Service diagnostics."
+  type        = string
+  default     = null
+}
+
+variable "app_service_app_settings" {
+  description = "Additional application settings applied to the primary web app."
+  type        = map(string)
+  default     = {}
+}
+
+variable "app_service_connection_strings" {
+  description = "Connection strings exposed to the primary web application."
+  type = map(object({
+    type  = string
+    value = string
+  }))
+  default = {}
+}
+
+variable "enable_arbitration_app_service" {
+  description = "Toggle deployment of the arbitration App Service."
+  type        = bool
+  default     = false
+}
+
+variable "arbitration_app_plan_sku" {
+  description = "Optional SKU override for the arbitration App Service plan."
+  type        = string
+  default     = null
+}
+
+variable "arbitration_runtime_stack" {
+  description = "Runtime stack for the arbitration App Service."
+  type        = string
+  default     = "dotnet"
+}
+
+variable "arbitration_runtime_version" {
+  description = "Runtime version for the arbitration App Service."
+  type        = string
+  default     = "8.0"
+}
+
+variable "arbitration_app_insights_connection_string" {
+  description = "Optional Application Insights connection string for the arbitration app (defaults to the primary web app string)."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.arbitration_app_insights_connection_string == null || trimspace(var.arbitration_app_insights_connection_string) != ""
+    error_message = "arbitration_app_insights_connection_string cannot be blank; omit it to reuse the primary web app setting."
+  }
+}
+
+variable "arbitration_log_analytics_workspace_id" {
+  description = "Optional Log Analytics workspace resource ID dedicated to the arbitration app."
+  type        = string
+  default     = null
+}
+
+variable "arbitration_app_settings" {
+  description = "Application settings applied to the arbitration App Service."
+  type        = map(string)
+  default     = {}
+}
+
+variable "arbitration_connection_strings" {
+  description = "Connection strings exposed to the arbitration App Service."
+  type = map(object({
+    type  = string
+    value = string
+  }))
+  default = {}
+}
+
+variable "arbitration_run_from_package" {
+  description = "Flag controlling WEBSITE_RUN_FROM_PACKAGE for the arbitration App Service."
+  type        = bool
+  default     = true
+}
+
+# -------------------------
 # Networking
 # -------------------------
 variable "vnet_address_space" {

--- a/platform/infra/envs/prod/main.tf
+++ b/platform/infra/envs/prod/main.tf
@@ -158,6 +158,44 @@ module "storage_private_endpoint" {
   ] : []
 }
 
+# App Services
+module "app_service_web" {
+  source = "../../Azure/modules/app-service-web"
+
+  name                = local.web_name
+  plan_name           = local.web_plan
+  plan_sku            = var.app_service_plan_sku
+  resource_group_name = module.resource_group.name
+  location            = var.location
+
+  dotnet_version                 = var.app_service_dotnet_version
+  app_insights_connection_string = var.app_service_app_insights_connection_string
+  log_analytics_workspace_id     = var.app_service_log_analytics_workspace_id
+  app_settings                   = var.app_service_app_settings
+  connection_strings             = var.app_service_connection_strings
+  tags                           = var.tags
+}
+
+module "app_service_arbitration" {
+  count = var.enable_arbitration_app_service ? 1 : 0
+  source = "../../Azure/modules/app-service-arbitration"
+
+  name                = local.arbitration_name
+  plan_name           = local.arbitration_plan
+  plan_sku            = var.arbitration_app_plan_sku != null && trimspace(var.arbitration_app_plan_sku) != "" ? var.arbitration_app_plan_sku : var.app_service_plan_sku
+  resource_group_name = module.resource_group.name
+  location            = var.location
+
+  runtime_stack                  = var.arbitration_runtime_stack
+  runtime_version                = var.arbitration_runtime_version
+  app_insights_connection_string = var.arbitration_app_insights_connection_string != null && trimspace(var.arbitration_app_insights_connection_string) != "" ? var.arbitration_app_insights_connection_string : var.app_service_app_insights_connection_string
+  log_analytics_workspace_id     = var.arbitration_log_analytics_workspace_id != null && trimspace(var.arbitration_log_analytics_workspace_id) != "" ? var.arbitration_log_analytics_workspace_id : var.app_service_log_analytics_workspace_id
+  connection_strings             = var.arbitration_connection_strings
+  app_settings                   = var.arbitration_app_settings
+  run_from_package               = var.arbitration_run_from_package
+  tags                           = var.tags
+}
+
 # NAT Gateway
 module "nat_gateway" {
   for_each = local.nat_gateway_settings == null ? {} : { default = local.nat_gateway_settings }

--- a/platform/infra/envs/prod/terraform.tfvars
+++ b/platform/infra/envs/prod/terraform.tfvars
@@ -60,6 +60,7 @@ dns_cname_records = {
 # -------------------------
 app_service_plan_sku    = "P2v3"
 app_service_fqdn_prefix = "app-arbit-prod"
+app_service_app_insights_connection_string = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-prod.vault.azure.net/secrets/app-service-appinsights-connection-string)"
 app_service_app_settings = {
   "WEBSITE_RUN_FROM_PACKAGE" = "0"
 }
@@ -73,10 +74,12 @@ app_service_connection_strings = {
 # -------------------------
 # Arbitration App
 # -------------------------
+enable_arbitration_app_service = true
 arbitration_app_settings = {
   "Storage__Connection" = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-prod.vault.azure.net/secrets/arbitration-storage-connection)"
   "Storage__Container"  = "arbitration-calculator"
 }
+arbitration_app_insights_connection_string = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-prod.vault.azure.net/secrets/arbitration-appinsights-connection-string)"
 
 # -------------------------
 # SQL Database

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -264,3 +264,112 @@ variable "storage_account_private_connection_resource_id" {
   type        = string
   default     = null
 }
+
+# -------------------------
+# App Services
+# -------------------------
+
+variable "app_service_plan_sku" {
+  description = "SKU for the App Service plan hosting the primary web application."
+  type        = string
+  default     = "B1"
+}
+
+variable "app_service_dotnet_version" {
+  description = ".NET runtime version for the primary web application."
+  type        = string
+  default     = "8.0"
+}
+
+variable "app_service_app_insights_connection_string" {
+  description = "Application Insights connection string injected into the primary web app."
+  type        = string
+
+  validation {
+    condition     = try(trimspace(var.app_service_app_insights_connection_string), "") != ""
+    error_message = "app_service_app_insights_connection_string must be provided when deploying the web app."
+  }
+}
+
+variable "app_service_log_analytics_workspace_id" {
+  description = "Optional Log Analytics workspace resource ID for App Service diagnostics."
+  type        = string
+  default     = null
+}
+
+variable "app_service_app_settings" {
+  description = "Additional application settings applied to the primary web app."
+  type        = map(string)
+  default     = {}
+}
+
+variable "app_service_connection_strings" {
+  description = "Connection strings exposed to the primary web application."
+  type = map(object({
+    type  = string
+    value = string
+  }))
+  default = {}
+}
+
+variable "enable_arbitration_app_service" {
+  description = "Toggle deployment of the arbitration App Service."
+  type        = bool
+  default     = false
+}
+
+variable "arbitration_app_plan_sku" {
+  description = "Optional SKU override for the arbitration App Service plan."
+  type        = string
+  default     = null
+}
+
+variable "arbitration_runtime_stack" {
+  description = "Runtime stack for the arbitration App Service."
+  type        = string
+  default     = "dotnet"
+}
+
+variable "arbitration_runtime_version" {
+  description = "Runtime version for the arbitration App Service."
+  type        = string
+  default     = "8.0"
+}
+
+variable "arbitration_app_insights_connection_string" {
+  description = "Optional Application Insights connection string for the arbitration app (defaults to the primary web app string)."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.arbitration_app_insights_connection_string == null || trimspace(var.arbitration_app_insights_connection_string) != ""
+    error_message = "arbitration_app_insights_connection_string cannot be blank; omit it to reuse the primary web app setting."
+  }
+}
+
+variable "arbitration_log_analytics_workspace_id" {
+  description = "Optional Log Analytics workspace resource ID dedicated to the arbitration app."
+  type        = string
+  default     = null
+}
+
+variable "arbitration_app_settings" {
+  description = "Application settings applied to the arbitration App Service."
+  type        = map(string)
+  default     = {}
+}
+
+variable "arbitration_connection_strings" {
+  description = "Connection strings exposed to the arbitration App Service."
+  type = map(object({
+    type  = string
+    value = string
+  }))
+  default = {}
+}
+
+variable "arbitration_run_from_package" {
+  description = "Flag controlling WEBSITE_RUN_FROM_PACKAGE for the arbitration App Service."
+  type        = bool
+  default     = true
+}

--- a/platform/infra/envs/stage/main.tf
+++ b/platform/infra/envs/stage/main.tf
@@ -160,6 +160,44 @@ module "storage_private_endpoint" {
   ] : []
 }
 
+# App Services
+module "app_service_web" {
+  source = "../../Azure/modules/app-service-web"
+
+  name                = local.web_name
+  plan_name           = local.web_plan
+  plan_sku            = var.app_service_plan_sku
+  resource_group_name = module.resource_group.name
+  location            = var.location
+
+  dotnet_version                 = var.app_service_dotnet_version
+  app_insights_connection_string = var.app_service_app_insights_connection_string
+  log_analytics_workspace_id     = var.app_service_log_analytics_workspace_id
+  app_settings                   = var.app_service_app_settings
+  connection_strings             = var.app_service_connection_strings
+  tags                           = var.tags
+}
+
+module "app_service_arbitration" {
+  count = var.enable_arbitration_app_service ? 1 : 0
+  source = "../../Azure/modules/app-service-arbitration"
+
+  name                = local.arbitration_name
+  plan_name           = local.arbitration_plan
+  plan_sku            = var.arbitration_app_plan_sku != null && trimspace(var.arbitration_app_plan_sku) != "" ? var.arbitration_app_plan_sku : var.app_service_plan_sku
+  resource_group_name = module.resource_group.name
+  location            = var.location
+
+  runtime_stack                  = var.arbitration_runtime_stack
+  runtime_version                = var.arbitration_runtime_version
+  app_insights_connection_string = var.arbitration_app_insights_connection_string != null && trimspace(var.arbitration_app_insights_connection_string) != "" ? var.arbitration_app_insights_connection_string : var.app_service_app_insights_connection_string
+  log_analytics_workspace_id     = var.arbitration_log_analytics_workspace_id != null && trimspace(var.arbitration_log_analytics_workspace_id) != "" ? var.arbitration_log_analytics_workspace_id : var.app_service_log_analytics_workspace_id
+  connection_strings             = var.arbitration_connection_strings
+  app_settings                   = var.arbitration_app_settings
+  run_from_package               = var.arbitration_run_from_package
+  tags                           = var.tags
+}
+
 # NAT & VPN
 module "nat_gateway" {
   for_each = local.nat_gateway_settings == null ? {} : { default = local.nat_gateway_settings }

--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -60,6 +60,7 @@ dns_cname_records = {
 # -------------------------
 app_service_plan_sku    = "P1v3"
 app_service_fqdn_prefix = "app-arbit-stage"
+app_service_app_insights_connection_string = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-stage.vault.azure.net/secrets/app-service-appinsights-connection-string)"
 app_service_app_settings = {
   "WEBSITE_RUN_FROM_PACKAGE" = "0"
 }
@@ -73,10 +74,12 @@ app_service_connection_strings = {
 # -------------------------
 # Arbitration App
 # -------------------------
+enable_arbitration_app_service = true
 arbitration_app_settings = {
   "Storage__Connection" = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-stage.vault.azure.net/secrets/arbitration-storage-connection)"
   "Storage__Container"  = "arbitration-calculator"
 }
+arbitration_app_insights_connection_string = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-stage.vault.azure.net/secrets/arbitration-appinsights-connection-string)"
 
 # -------------------------
 # SQL Database

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -264,3 +264,112 @@ variable "storage_account_private_connection_resource_id" {
   type        = string
   default     = null
 }
+
+# -------------------------
+# App Services
+# -------------------------
+
+variable "app_service_plan_sku" {
+  description = "SKU for the App Service plan hosting the primary web application."
+  type        = string
+  default     = "B1"
+}
+
+variable "app_service_dotnet_version" {
+  description = ".NET runtime version for the primary web application."
+  type        = string
+  default     = "8.0"
+}
+
+variable "app_service_app_insights_connection_string" {
+  description = "Application Insights connection string injected into the primary web app."
+  type        = string
+
+  validation {
+    condition     = try(trimspace(var.app_service_app_insights_connection_string), "") != ""
+    error_message = "app_service_app_insights_connection_string must be provided when deploying the web app."
+  }
+}
+
+variable "app_service_log_analytics_workspace_id" {
+  description = "Optional Log Analytics workspace resource ID for App Service diagnostics."
+  type        = string
+  default     = null
+}
+
+variable "app_service_app_settings" {
+  description = "Additional application settings applied to the primary web app."
+  type        = map(string)
+  default     = {}
+}
+
+variable "app_service_connection_strings" {
+  description = "Connection strings exposed to the primary web application."
+  type = map(object({
+    type  = string
+    value = string
+  }))
+  default = {}
+}
+
+variable "enable_arbitration_app_service" {
+  description = "Toggle deployment of the arbitration App Service."
+  type        = bool
+  default     = false
+}
+
+variable "arbitration_app_plan_sku" {
+  description = "Optional SKU override for the arbitration App Service plan."
+  type        = string
+  default     = null
+}
+
+variable "arbitration_runtime_stack" {
+  description = "Runtime stack for the arbitration App Service."
+  type        = string
+  default     = "dotnet"
+}
+
+variable "arbitration_runtime_version" {
+  description = "Runtime version for the arbitration App Service."
+  type        = string
+  default     = "8.0"
+}
+
+variable "arbitration_app_insights_connection_string" {
+  description = "Optional Application Insights connection string for the arbitration app (defaults to the primary web app string)."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.arbitration_app_insights_connection_string == null || trimspace(var.arbitration_app_insights_connection_string) != ""
+    error_message = "arbitration_app_insights_connection_string cannot be blank; omit it to reuse the primary web app setting."
+  }
+}
+
+variable "arbitration_log_analytics_workspace_id" {
+  description = "Optional Log Analytics workspace resource ID dedicated to the arbitration app."
+  type        = string
+  default     = null
+}
+
+variable "arbitration_app_settings" {
+  description = "Application settings applied to the arbitration App Service."
+  type        = map(string)
+  default     = {}
+}
+
+variable "arbitration_connection_strings" {
+  description = "Connection strings exposed to the arbitration App Service."
+  type = map(object({
+    type  = string
+    value = string
+  }))
+  default = {}
+}
+
+variable "arbitration_run_from_package" {
+  description = "Flag controlling WEBSITE_RUN_FROM_PACKAGE for the arbitration App Service."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Summary
- add connection string support to the shared app-service-web module
- wire the web and arbitration app-service modules into the dev, stage, and prod environments with the required variables
- populate each environment's terraform.tfvars with the runtime values for the new services

## Testing
- terraform fmt -recursive *(fails: terraform binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c96a4b2a988326adf770582e86ed74