### PR TITLE
Add versions.tf to Azure modules

### DIFF
--- a/platform/infra/Azure/modules/aad-app/versions.tf
+++ b/platform/infra/Azure/modules/aad-app/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/acr/versions.tf
+++ b/platform/infra/Azure/modules/acr/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/aks/versions.tf
+++ b/platform/infra/Azure/modules/aks/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/app-gateway/versions.tf
+++ b/platform/infra/Azure/modules/app-gateway/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/app-insights/versions.tf
+++ b/platform/infra/Azure/modules/app-insights/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/app-service-arbitration/versions.tf
+++ b/platform/infra/Azure/modules/app-service-arbitration/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/app-service-web/versions.tf
+++ b/platform/infra/Azure/modules/app-service-web/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/app-service/versions.tf
+++ b/platform/infra/Azure/modules/app-service/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/bastion/versions.tf
+++ b/platform/infra/Azure/modules/bastion/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/dns-zone/versions.tf
+++ b/platform/infra/Azure/modules/dns-zone/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/function-app/versions.tf
+++ b/platform/infra/Azure/modules/function-app/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/key-vault/versions.tf
+++ b/platform/infra/Azure/modules/key-vault/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/lb-rule/versions.tf
+++ b/platform/infra/Azure/modules/lb-rule/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/lb/versions.tf
+++ b/platform/infra/Azure/modules/lb/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/linux-function-app/versions.tf
+++ b/platform/infra/Azure/modules/linux-function-app/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/linux-virtual-machine/versions.tf
+++ b/platform/infra/Azure/modules/linux-virtual-machine/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/linux-web-app/versions.tf
+++ b/platform/infra/Azure/modules/linux-web-app/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/managed-disk/versions.tf
+++ b/platform/infra/Azure/modules/managed-disk/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/mssql-database/versions.tf
+++ b/platform/infra/Azure/modules/mssql-database/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/mssql-server/versions.tf
+++ b/platform/infra/Azure/modules/mssql-server/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/nat-gateway/versions.tf
+++ b/platform/infra/Azure/modules/nat-gateway/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/network-security-group/versions.tf
+++ b/platform/infra/Azure/modules/network-security-group/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/network/versions.tf
+++ b/platform/infra/Azure/modules/network/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/private-endpoint/versions.tf
+++ b/platform/infra/Azure/modules/private-endpoint/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/resource-group/versions.tf
+++ b/platform/infra/Azure/modules/resource-group/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/sql-database/versions.tf
+++ b/platform/infra/Azure/modules/sql-database/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/sql-serverless/versions.tf
+++ b/platform/infra/Azure/modules/sql-serverless/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/storage-account/versions.tf
+++ b/platform/infra/Azure/modules/storage-account/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/storage-container/versions.tf
+++ b/platform/infra/Azure/modules/storage-container/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/virtual-machine-data-disk-attachment/versions.tf
+++ b/platform/infra/Azure/modules/virtual-machine-data-disk-attachment/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/platform/infra/Azure/modules/vpn-gateway/versions.tf
+++ b/platform/infra/Azure/modules/vpn-gateway/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}


### PR DESCRIPTION
## Summary
- add Terraform `versions.tf` files to each Azure module so they share the standard version and provider constraints

## Testing
- `for dir in platform/infra/Azure/modules/*/; do (cd "$dir" && terraform fmt); done` *(fails: terraform binary is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9767fddd48326a56c57d2adb5ea45