### PR TITLE
Use per-environment Terraform state containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ARBIT centralizes cloud infrastructure for development, staging, and production 
 
 1. **Create ADO service connections (OIDC):** `sc-azure-oidc-dev`, `sc-azure-oidc-stage`, `sc-azure-oidc-prod` scoped to the target subscription/resource group with **Storage Blob Data Contributor** on the Terraform state storage account.
 2. **Create ADO environments:** `dev`, `stage`, `prod`. Require approvals for stage and prod (optionally add branch control or business-hours policies).
-3. **Verify remote state backends:** Each `platform/infra/envs/<env>/backend.tfvars` is prefilled; keep `use_azuread_auth = true` and update resource names if they differ in your tenant.
+3. **Verify remote state backends:** Each `platform/infra/envs/<env>/backend.tfvars` is prefilled; keep `use_azuread_auth = true` and update resource names if they differ in your tenant. Storage containers now use the pattern `arbit-<env>` so that each environment isolates its state blob.
 4. **Import the pipeline:** Point Azure DevOps to the root `azure-pipelines.yml` multi-stage pipeline.
 5. **Open a test pull request:** Review the three plan artifacts, merge to trigger the dev apply, and approve stage/prod when ready.
 
@@ -145,7 +145,7 @@ arbit-consolidated-infra-ado/
 | Lock timeout | `TF_LOCK_TIMEOUT` variable | Default `20m`; increase if state contention occurs. |
 | Service connections | Parameters in plan/apply templates | Rename to match your ADO service connections. |
 | Feature toggles | `platform/infra/envs/<env>/terraform.tfvars` | Toggle modules (Storage, SQL, AKS/ACR, Key Vault access). |
-| Backend coordinates | `platform/infra/envs/<env>/backend.tfvars` | Update RG/Storage/Container names per environment. |
+| Backend coordinates | `platform/infra/envs/<env>/backend.tfvars` | Update RG/Storage/Container names per environment (containers follow `arbit-<env>`). |
 | SQL admin credentials | ADO variable groups / Key Vault / secure `terraform.tfvars` | Required when `enable_sql = true`; provide before running plan/apply. |
 
 ### Manual runs and re-runs

--- a/docs/network/Resource per Env for the Arbit project.txt
+++ b/docs/network/Resource per Env for the Arbit project.txt
@@ -7,7 +7,7 @@ location     = "eastus"
 env          = "dev"
 
 env_name            = "dev"
-container_name      = "arbit"
+container_name      = "arbit-dev"
 subscription_id     = "930755b1-ef22-4721-a31a-1b6fbecf7da6"
 tenant_id           = "70750cc4-6f21-4c27-bb0e-8b7e66bcb2dd"
 resource_group_name = "dev-eus2-ops-rg-1"
@@ -50,7 +50,7 @@ sql_public_network_access = true
 
 resource_group_name  = "dev-eus2-ops-rg-1"
 storage_account_name = "deveus2terraform"
-container_name       = "arbit"
+container_name       = "arbit-dev"
 key                  = "arbit/dev.tfstate"
 use_azuread_auth     = true
 subscription_id = "930755b1-ef22-4721-a31a-1b6fbecf7da6"
@@ -97,8 +97,8 @@ sql_public_network_access = true
 
 resource_group_name  = "prod-eus2-ops-rg-1"
 storage_account_name = "prodeus2terraform"
-container_name       = "arbit"
-key                  = "arbit/prod.tfstate"
+container_name       = "arbit-prod"
+key                  = "halomd-prod-tfstate-kv"
 use_azuread_auth     = true
 
 
@@ -141,7 +141,7 @@ sql_public_network_access = true
 
 
 resource_group_name  = "staging-eus2-ops-rg-1"
-storage_account_name = "deveus2terraform"
-container_name       = "arbit"
-key                  = "arbit/stage.tfstate"
+storage_account_name = "stageeus2terraform"
+container_name       = "arbit-stage"
+key                  = "halomd-stage-tfstate-kv"
 use_azuread_auth     = true

--- a/docs/state-migration.md
+++ b/docs/state-migration.md
@@ -2,3 +2,14 @@
 - Point new root at the same backend (init -reconfigure).
 - Use `terraform state mv` for module path refactors.
 - Ensure a no-op plan before switching CI/CD.
+
+## Moving state into per-environment containers
+
+Each environment now stores Terraform state in its own container (`arbit-dev`, `arbit-stage`, `arbit-prod`). To migrate existing state from the legacy shared container:
+
+1. In each environment directory run `terraform init -reconfigure -backend-config=backend.legacy.tfvars` (or temporarily restore the previous backend settings) and `terraform state pull > <env>.tfstate` to export the current state locally.
+2. Update `backend.tfvars` to point at the new container (see `platform/infra/envs/<env>/backend.tfvars`).
+3. Run `terraform init -reconfigure -backend-config=backend.tfvars` so Terraform writes the `.terraform` metadata for the new backend.
+4. Push the saved state into the new container with `terraform state push <env>.tfstate` and rerun `terraform plan` to confirm a no-op.
+
+> Tip: You can also copy the blob directly with `az storage blob copy start --destination-container arbit-<env> --destination-blob <state-key> --source-container arbit --source-blob <state-key>`, then rerun `terraform init -reconfigure` to verify.

--- a/platform/infra/envs/dev/backend.tfvars
+++ b/platform/infra/envs/dev/backend.tfvars
@@ -1,7 +1,7 @@
 
 resource_group_name = "dev-eus2-ops-rg-1"
 storage_account_name = "deveus2terraform"
-container_name = "arbit"
+container_name = "arbit-dev"
 key = "arbit/dev.tfstate"
 use_azuread_auth = true
 # subscription_id and tenant_id are supplied at runtime (e.g. via

--- a/platform/infra/envs/prod/backend.tfvars
+++ b/platform/infra/envs/prod/backend.tfvars
@@ -1,7 +1,7 @@
 
 resource_group_name  = "prod-eus2-ops-rg-1"
 storage_account_name = "prodeus2terraform"
-container_name       = "arbit"
+container_name       = "arbit-prod"
 key                  = "halomd-prod-tfstate-kv"
 use_azuread_auth     = true
 subscription_id = "40f3e169-b544-4789-936a-5526146e3b8e"

--- a/platform/infra/envs/stage/backend.tfvars
+++ b/platform/infra/envs/stage/backend.tfvars
@@ -1,7 +1,7 @@
 
 resource_group_name  = "staging-eus2-ops-rg-1"
 storage_account_name = "stageeus2terraform"
-container_name       = "arbit"
+container_name       = "arbit-stage"
 key                  = "halomd-stage-tfstate-kv"
 use_azuread_auth     = true
 subscription_id = "6f6a108b-c1fa-4d44-adb9-60e5de23f405"

--- a/scripts/azure-bootstrap-tfstate.ps1
+++ b/scripts/azure-bootstrap-tfstate.ps1
@@ -3,11 +3,13 @@ param(
   [string]$ResourceGroup = "rg-tfstate-eastus",
   [string]$Location      = "eastus",
   [string]$StorageAcct   = "stcodextfstate01",
-  [string]$Container     = "tfstate"
+  [string]$ContainerPrefix = "arbit"
 )
 az account set --subscription $SubscriptionId | Out-Null
 az group create -n $ResourceGroup -l $Location -o none | Out-Null
 az storage account create -g $ResourceGroup -n $StorageAcct -l $Location --sku Standard_LRS --kind StorageV2 --min-tls-version TLS1_2 --allow-blob-public-access false -o none | Out-Null
 $Key = az storage account keys list -g $ResourceGroup -n $StorageAcct --query "[0].value" -o tsv
-az storage container create --name $Container --account-name $StorageAcct --account-key $Key -o none | Out-Null
-Write-Host "backend.tfvars -> rg=$ResourceGroup sa=$StorageAcct container=$Container key=arbit/<env>.tfstate use_azuread_auth=true"
+foreach ($env in @('dev', 'stage', 'prod')) {
+  az storage container create --name "$ContainerPrefix-$env" --account-name $StorageAcct --account-key $Key -o none | Out-Null
+}
+Write-Host "backend.tfvars -> rg=$ResourceGroup sa=$StorageAcct container=$ContainerPrefix-<env> key=<env>-specific-state-key use_azuread_auth=true"

--- a/scripts/azure-bootstrap-tfstate.sh
+++ b/scripts/azure-bootstrap-tfstate.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
-SUB=${1:?Subscription ID required}; RG=${2:-rg-tfstate-eastus}; LOC=${3:-eastus}; SA=${4:-stcodextfstate01}; CN=${5:-tfstate}
+SUB=${1:?Subscription ID required}; RG=${2:-rg-tfstate-eastus}; LOC=${3:-eastus}; SA=${4:-stcodextfstate01}; CN_PREFIX=${5:-arbit}
 az account set --subscription "$SUB"
 az group create -n "$RG" -l "$LOC" -o none
 az storage account create -g "$RG" -n "$SA" -l "$LOC" --sku Standard_LRS --kind StorageV2 --min-tls-version TLS1_2 --allow-blob-public-access false -o none
 KEY=$(az storage account keys list -g "$RG" -n "$SA" --query "[0].value" -o tsv)
-az storage container create --name "$CN" --account-name "$SA" --account-key "$KEY" -o none
-echo "backend.tfvars -> rg=$RG sa=$SA container=$CN key=arbit/<env>.tfstate use_azuread_auth=true"
+for ENV in dev stage prod; do
+  az storage container create --name "${CN_PREFIX}-${ENV}" --account-name "$SA" --account-key "$KEY" -o none
+done
+echo "backend.tfvars -> rg=$RG sa=$SA container=${CN_PREFIX}-<env> key=<env>-specific-state-key use_azuread_auth=true"


### PR DESCRIPTION
## Summary
- configure each environment backend to use a dedicated Azure Storage container (arbit-dev/stage/prod)
- update bootstrap scripts and documentation with the new container pattern and migration guidance

## Testing
- not run (configuration/documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68c97683079c8326a90bd680ce8b02e4