### PR TITLE
Add terraform run helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ arbit-consolidated-infra-ado/
 - **Re-run failed stages:** Apply stages reuse the saved plan artifact to maintain integrity.
 - **Redeploy from Environments:** Trigger a redeploy of the last successful run for a given environment using the stored artifact.
 
+### Local Terraform helper script
+
+- Use [`scripts/run-terraform.sh`](scripts/run-terraform.sh) to execute a one-shot `terraform init` + `terraform apply` for a specific environment.
+- Syntax: `./scripts/run-terraform.sh <dev|qa|stage|prod>` (the script validates the environment and requires `terraform` in your `PATH`).
+- Run the script from any directory; it automatically changes to `platform/infra/envs/<env>`, loads `backend.tfvars`, and applies using `terraform.tfvars` with `-auto-approve`.
+
 ### Security and governance
 
 - Enforce least privilege by scoping service connections to the minimal subscription/resource group.

--- a/scripts/run-terraform.sh
+++ b/scripts/run-terraform.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") <dev|qa|stage|prod>
+
+Initializes and applies the Terraform configuration for the specified environment.
+USAGE
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 1
+fi
+
+ENVIRONMENT="${1,,}"
+
+case "$ENVIRONMENT" in
+  dev|qa|stage|prod)
+    ;;
+  *)
+    echo "[ERROR] Unsupported environment: $1" >&2
+    usage
+    exit 1
+    ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_DIR="$REPO_ROOT/platform/infra/envs/$ENVIRONMENT"
+
+if [[ ! -d "$ENV_DIR" ]]; then
+  echo "[ERROR] Terraform environment directory not found: $ENV_DIR" >&2
+  exit 1
+fi
+
+BACKEND_VARS_FILE="$ENV_DIR/backend.tfvars"
+TFVARS_FILE="$ENV_DIR/terraform.tfvars"
+
+if [[ ! -f "$BACKEND_VARS_FILE" ]]; then
+  echo "[ERROR] backend.tfvars not found at $BACKEND_VARS_FILE" >&2
+  exit 1
+fi
+
+if [[ ! -f "$TFVARS_FILE" ]]; then
+  echo "[ERROR] terraform.tfvars not found at $TFVARS_FILE" >&2
+  exit 1
+fi
+
+if ! command -v terraform >/dev/null 2>&1; then
+  echo "[ERROR] terraform command not found in PATH." >&2
+  exit 1
+fi
+
+pushd "$ENV_DIR" >/dev/null
+
+echo "[INFO] Initializing Terraform backend for $ENVIRONMENT"
+terraform init -reconfigure -backend-config="$(basename "$BACKEND_VARS_FILE")"
+
+echo "[INFO] Applying Terraform configuration for $ENVIRONMENT"
+terraform apply -var-file="$(basename "$TFVARS_FILE")" -auto-approve
+
+popd >/dev/null


### PR DESCRIPTION
## Summary
- add a bash helper script that runs terraform init/apply for a chosen environment
- document the new script usage in the README

## Testing
- bash -n scripts/run-terraform.sh

------
https://chatgpt.com/codex/tasks/task_e_68c995c91cb08326b7694026f6a08d3f