### PR TITLE
Define arbitration web app configuration maps

### DIFF
--- a/docs/SECRETS-AKV.md
+++ b/docs/SECRETS-AKV.md
@@ -70,6 +70,34 @@ Create these secrets **in each environment’s Key Vault** (names configurable v
 - `arbitration-idr-connection`
 - `arbitration-storage-connection`
 
+### Arbitration web app configuration maps
+
+Populate the following keys in each environment's Terraform inputs so the arbitration App Service has storage and database connectivity:
+
+#### dev
+- `arbitration_app_settings`
+  - `Storage__Connection` → `@Microsoft.KeyVault(SecretUri=https://kv-arbit-dev.vault.azure.net/secrets/arbitration-storage-connection)`
+  - `Storage__Container`  → `arbitration-calculator`
+- `arbitration_connection_strings`
+  - `ConnStr`     → `@Microsoft.KeyVault(SecretUri=https://kv-arbit-dev.vault.azure.net/secrets/arbitration-primary-connection)`
+  - `IDRConnStr`  → `@Microsoft.KeyVault(SecretUri=https://kv-arbit-dev.vault.azure.net/secrets/arbitration-idr-connection)`
+
+#### stage
+- `arbitration_app_settings`
+  - `Storage__Connection` → `@Microsoft.KeyVault(SecretUri=https://kv-arbit-stage.vault.azure.net/secrets/arbitration-storage-connection)`
+  - `Storage__Container`  → `arbitration-calculator`
+- `arbitration_connection_strings`
+  - `ConnStr`     → `@Microsoft.KeyVault(SecretUri=https://kv-arbit-stage.vault.azure.net/secrets/arbitration-primary-connection)`
+  - `IDRConnStr`  → `@Microsoft.KeyVault(SecretUri=https://kv-arbit-stage.vault.azure.net/secrets/arbitration-idr-connection)`
+
+#### prod
+- `arbitration_app_settings`
+  - `Storage__Connection` → `@Microsoft.KeyVault(SecretUri=https://kv-arbit-prod.vault.azure.net/secrets/arbitration-storage-connection)`
+  - `Storage__Container`  → `arbitration-calculator`
+- `arbitration_connection_strings`
+  - `ConnStr`     → `@Microsoft.KeyVault(SecretUri=https://kv-arbit-prod.vault.azure.net/secrets/arbitration-primary-connection)`
+  - `IDRConnStr`  → `@Microsoft.KeyVault(SecretUri=https://kv-arbit-prod.vault.azure.net/secrets/arbitration-idr-connection)`
+
 You can add more (e.g., `webapp-client-secret`) and extend the YAML similarly.
 
 > App Service / Function apps must have managed identities with **Key Vault Secrets User** access so the runtime can resolve `@Microsoft.KeyVault(...)` references configured in Terraform.

--- a/platform/infra/envs/dev/terraform.tfvars
+++ b/platform/infra/envs/dev/terraform.tfvars
@@ -60,4 +60,17 @@ arbitration_app_settings = {
   "Storage__Connection" = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-dev.vault.azure.net/secrets/arbitration-storage-connection)"
   "Storage__Container"  = "arbitration-calculator"
 }
+# Required keys:
+#   - ConnStr: primary arbitration database
+#   - IDRConnStr: IDR arbitration database
+arbitration_connection_strings = {
+  ConnStr = {
+    type  = "SQLAzure"
+    value = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-dev.vault.azure.net/secrets/arbitration-primary-connection)"
+  }
+  IDRConnStr = {
+    type  = "SQLAzure"
+    value = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-dev.vault.azure.net/secrets/arbitration-idr-connection)"
+  }
+}
 arbitration_app_insights_connection_string = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-dev.vault.azure.net/secrets/arbitration-appinsights-connection-string)"

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -517,13 +517,13 @@ variable "arbitration_log_analytics_workspace_id" {
 }
 
 variable "arbitration_app_settings" {
-  description = "Application settings applied to the arbitration App Service."
+  description = "Application settings applied to the arbitration App Service (expects Storage__Connection and Storage__Container entries)."
   type        = map(string)
   default     = {}
 }
 
 variable "arbitration_connection_strings" {
-  description = "Connection strings exposed to the arbitration App Service."
+  description = "Connection strings exposed to the arbitration App Service (expects ConnStr and IDRConnStr entries sourced from Key Vault)."
   type = map(object({
     type  = string
     value = string

--- a/platform/infra/envs/prod/terraform.tfvars
+++ b/platform/infra/envs/prod/terraform.tfvars
@@ -102,6 +102,19 @@ arbitration_app_settings = {
   "Storage__Connection" = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-prod.vault.azure.net/secrets/arbitration-storage-connection)"
   "Storage__Container"  = "arbitration-calculator"
 }
+# Required keys:
+#   - ConnStr: primary arbitration database
+#   - IDRConnStr: IDR arbitration database
+arbitration_connection_strings = {
+  ConnStr = {
+    type  = "SQLAzure"
+    value = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-prod.vault.azure.net/secrets/arbitration-primary-connection)"
+  }
+  IDRConnStr = {
+    type  = "SQLAzure"
+    value = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-prod.vault.azure.net/secrets/arbitration-idr-connection)"
+  }
+}
 arbitration_app_insights_connection_string = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-prod.vault.azure.net/secrets/arbitration-appinsights-connection-string)"
 
 # -------------------------

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -210,13 +210,13 @@ variable "arbitration_log_analytics_workspace_id" {
 }
 
 variable "arbitration_app_settings" {
-  description = "Application settings applied to the arbitration App Service."
+  description = "Application settings applied to the arbitration App Service (expects Storage__Connection and Storage__Container entries)."
   type        = map(string)
   default     = {}
 }
 
 variable "arbitration_connection_strings" {
-  description = "Connection strings exposed to the arbitration App Service."
+  description = "Connection strings exposed to the arbitration App Service (expects ConnStr and IDRConnStr entries sourced from Key Vault)."
   type = map(object({
     type  = string
     value = string

--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -102,6 +102,19 @@ arbitration_app_settings = {
   "Storage__Connection" = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-stage.vault.azure.net/secrets/arbitration-storage-connection)"
   "Storage__Container"  = "arbitration-calculator"
 }
+# Required keys:
+#   - ConnStr: primary arbitration database
+#   - IDRConnStr: IDR arbitration database
+arbitration_connection_strings = {
+  ConnStr = {
+    type  = "SQLAzure"
+    value = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-stage.vault.azure.net/secrets/arbitration-primary-connection)"
+  }
+  IDRConnStr = {
+    type  = "SQLAzure"
+    value = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-stage.vault.azure.net/secrets/arbitration-idr-connection)"
+  }
+}
 arbitration_app_insights_connection_string = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-stage.vault.azure.net/secrets/arbitration-appinsights-connection-string)"
 
 # -------------------------

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -210,13 +210,13 @@ variable "arbitration_log_analytics_workspace_id" {
 }
 
 variable "arbitration_app_settings" {
-  description = "Application settings applied to the arbitration App Service."
+  description = "Application settings applied to the arbitration App Service (expects Storage__Connection and Storage__Container entries)."
   type        = map(string)
   default     = {}
 }
 
 variable "arbitration_connection_strings" {
-  description = "Connection strings exposed to the arbitration App Service."
+  description = "Connection strings exposed to the arbitration App Service (expects ConnStr and IDRConnStr entries sourced from Key Vault)."
   type = map(object({
     type  = string
     value = string


### PR DESCRIPTION
## Summary
- add arbitration connection string definitions for dev, stage, and prod environments so the web module receives required database secrets
- clarify arbitration app setting expectations in each environment's variable definitions
- document the per-environment arbitration configuration keys in the AKV secrets guide

## Testing
- ⚠️ `terraform fmt platform/infra/envs/dev` *(fails: terraform is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c995c55e288326a6c8dbfda47047aa