### PR TITLE
Add QA infrastructure environment

### DIFF
--- a/.ado/pipelines/arbitration-app.yml
+++ b/.ado/pipelines/arbitration-app.yml
@@ -1,5 +1,5 @@
 # Azure DevOps multi-stage pipeline for the Arbitration web application
-# Build -> Deploy (dev -> stage -> prod)
+# Build -> Deploy (dev -> qa -> stage -> prod)
 # Environment approvals for stage/prod should be configured on the
 # corresponding Azure DevOps environments (arbitration-stage, arbitration-prod).
 
@@ -37,9 +37,23 @@ stages:
       displayNameSuffix: dev
       azureSubscription: sc-azure-oidc-dev
 
+- stage: deploy_qa
+  displayName: Deploy to qa
+  dependsOn: deploy_dev
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  variables:
+  - group: arbitration-app-qa  # provides webAppName/appSettingsJson/connectionStringsJson
+  jobs:
+  - template: .ado/templates/arbitration-deploy.yml
+    parameters:
+      jobName: deploy_qa
+      environmentName: arbitration-qa
+      displayNameSuffix: qa
+      azureSubscription: sc-azure-oidc-qa
+
 - stage: deploy_stage
   displayName: Deploy to stage
-  dependsOn: deploy_dev
+  dependsOn: deploy_qa
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   variables:
   - group: arbitration-app-stage  # provides webAppName/appSettingsJson/connectionStringsJson

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,7 @@
 variables:
   - group: terraform-global-common
   - group: terraform-dev        # for Validate & Plan dev
+  - group: terraform-qa         # used during Plan_All and Apply_QA
   - group: terraform-stage      # used during Plan_All and Apply_Stage
   - group: terraform-prod       # used during Plan_All and Apply_Prod
   - name: nodeVersion
@@ -63,7 +64,7 @@ stages:
       dependsOn: build_arbitration
 
 - stage: Plan_All
-  displayName: Terraform Plan (dev, stage, prod)
+  displayName: Terraform Plan (dev, qa, stage, prod)
   dependsOn: Validate
   jobs:
   - template: .ado/templates/tf-plan.yml
@@ -77,6 +78,19 @@ stages:
       useAkv: '$(USE_AKV_FOR_SECRETS)'
       akvName: '$(KV_NAME_DEV)'
       akvEnableDynamicIp: '$(AKV_ENABLE_DYNAMIC_IP_DEV)'
+      akvSecretSqlAdminLoginName: '$(AKV_SECRET_SQL_ADMIN_LOGIN_NAME)'
+      akvSecretSqlAdminPasswordName: '$(AKV_SECRET_SQL_ADMIN_PASSWORD_NAME)'
+  - template: .ado/templates/tf-plan.yml
+    parameters:
+      envName: qa
+      serviceConnection: sc-azure-oidc-qa
+      tfVersion: ${{ variables.TF_VERSION }}
+      lockTimeout: ${{ variables.TF_LOCK_TIMEOUT }}
+      variableGroup: terraform-qa
+      extraVarFlags: '-var "kv_cicd_principal_id=$(KV_CICD_PRINCIPAL_ID_QA)"'
+      useAkv: '$(USE_AKV_FOR_SECRETS)'
+      akvName: '$(KV_NAME_QA)'
+      akvEnableDynamicIp: '$(AKV_ENABLE_DYNAMIC_IP_QA)'
       akvSecretSqlAdminLoginName: '$(AKV_SECRET_SQL_ADMIN_LOGIN_NAME)'
       akvSecretSqlAdminPasswordName: '$(AKV_SECRET_SQL_ADMIN_PASSWORD_NAME)'
   - template: .ado/templates/tf-plan.yml
@@ -119,9 +133,22 @@ stages:
       lockTimeout: ${{ variables.TF_LOCK_TIMEOUT }}
       variableGroup: terraform-dev
 
+- stage: Apply_QA
+  displayName: Terraform Apply (qa)
+  dependsOn: Apply_Dev
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  jobs:
+  - template: .ado/templates/tf-apply.yml
+    parameters:
+      envName: qa
+      serviceConnection: sc-azure-oidc-qa
+      tfVersion: ${{ variables.TF_VERSION }}
+      lockTimeout: ${{ variables.TF_LOCK_TIMEOUT }}
+      variableGroup: terraform-qa
+
 - stage: Apply_Stage
   displayName: Terraform Apply (stage)
-  dependsOn: Apply_Dev
+  dependsOn: Apply_QA
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   jobs:
   - template: .ado/templates/tf-apply.yml

--- a/docs/ADO-CICD-Workflow.md
+++ b/docs/ADO-CICD-Workflow.md
@@ -1,8 +1,8 @@
 # ADO Terraform CI/CD — Full Workflow (Multi‑Stage)
 
 See diagrams and steps in `DEV-Deploy-With-Branching.md` for branch context. This pipeline:
-- PR → Validate + Plan (dev/stage/prod)
-- Merge → Apply dev (auto)
+- PR → Validate + Plan (dev/qa/stage/prod)
+- Merge → Apply dev & qa (auto)
 - Stage/Prod → approvals
 
 Key Vault integration is described in `SECRETS-AKV.md`.

--- a/docs/ADO-setup.md
+++ b/docs/ADO-setup.md
@@ -1,15 +1,16 @@
 # Azure DevOps (ADO) Setup
 
 ## Service Connections (OIDC)
-Create three **Azure Resource Manager** service connections with **Workload identity federation**:
+Create four **Azure Resource Manager** service connections with **Workload identity federation**:
 - `sc-azure-oidc-dev`
+- `sc-azure-oidc-qa`
 - `sc-azure-oidc-stage`
 - `sc-azure-oidc-prod`
 
 Grant **Contributor** on the target scope and **Storage Blob Data Contributor** on the Terraform state storage account used by your backends.
 
 ## Environments & Approvals
-Create **Environments**: `dev`, `stage`, `prod`.
+Create **Environments**: `dev`, `qa`, `stage`, `prod`.
 - Add **Approvals** for `stage` and `prod` (SRE/lead/change approvers).
 - (Optional) Add **Branch control** to allow only `refs/heads/main`.
 

--- a/docs/network/Resource per Env for the Arbit project.txt
+++ b/docs/network/Resource per Env for the Arbit project.txt
@@ -58,6 +58,52 @@ tenant_id       = "70750cc4-6f21-4c27-bb0e-8b7e66bcb2dd"
 
 
 
+QA Env:
+
+project_name = "arbit"
+location     = "eastus"
+env          = "qa"
+
+tags = {
+  project = "arbit"
+  env     = "qa"
+  owner   = "platform"
+}
+
+enable_aks      = false
+enable_acr      = false
+enable_storage  = false
+enable_sql      = false
+kv_public_network_access = true
+
+acr_sku        = "Basic"
+aks_node_count = 1
+aks_vm_size    = "Standard_DS2_v2"
+web_plan_sku   = "B1"
+func_plan_sku  = "Y1"
+
+web_dotnet_version        = "8.0"
+function_external_runtime = "dotnet"
+function_cron_runtime     = "python"
+
+sql_db_name               = "halomd"
+sql_sku_name              = "GP_S_Gen5_2"
+sql_auto_pause_delay      = 60
+sql_max_size_gb           = 32
+sql_public_network_access = true
+# sql_admin_login    = ""
+# sql_admin_password = ""
+
+
+
+resource_group_name  = "qa-eus2-ops-rg-1"
+storage_account_name = "qaeus2terraform"
+container_name       = "arbit-qa"
+key                  = "arbit/qa.tfstate"
+use_azuread_auth     = true
+
+
+
 Prod Env:
 
 project_name = "arbit"

--- a/docs/step-by-step.md
+++ b/docs/step-by-step.md
@@ -1,6 +1,6 @@
 # Step-by-step Setup (ADO)
-1) Create OIDC service connections: `sc-azure-oidc-dev|stage|prod`.
-2) Create ADO Environments: `dev`, `stage`, `prod` (add approvals for stage/prod).
+1) Create OIDC service connections: `sc-azure-oidc-dev|qa|stage|prod`.
+2) Create ADO Environments: `dev`, `qa`, `stage`, `prod` (add approvals for stage/prod).
 3) Ensure `backend.tfvars` in each env points to your tfstate and `use_azuread_auth = true`.
 4) Import pipeline: `azure-pipelines.yml`.
-5) Open a PR to test plans; merge to apply Dev; approve for stage/prod.
+5) Open a PR to test plans; merge to apply Dev and QA; approve for stage/prod.

--- a/platform/infra/envs/qa/backend.tf
+++ b/platform/infra/envs/qa/backend.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  backend "azurerm" {}
+}

--- a/platform/infra/envs/qa/main.tf
+++ b/platform/infra/envs/qa/main.tf
@@ -1,0 +1,204 @@
+# Environment composition for the qa environment
+
+locals {
+  rg_name                      = "rg-${var.project_name}-${var.env_name}"
+  kv_name                      = "kv-${var.project_name}-${var.env_name}"
+  bastion_name                 = "bas-${var.project_name}-${var.env_name}"
+  log_name                     = var.log_analytics_workspace_name
+  appi_name                    = var.application_insights_name
+
+  kv_private_endpoint_name      = "pep-${var.project_name}-${var.env_name}-kv"
+  storage_private_endpoint_name = "pep-${var.project_name}-${var.env_name}-st"
+
+  # App Service naming
+  app_service_plan_name         = "asp-${var.project_name}-web-${var.env_name}-${var.location}"
+  app_service_name              = "app-${var.project_name}-web-${var.env_name}"
+  arbitration_plan_name         = "asp-${var.project_name}-arb-${var.env_name}-${var.location}"
+  arbitration_app_name          = "app-${var.project_name}-arb-${var.env_name}"
+
+  # SQL Server
+  sql_server_name               = "sql-${var.project_name}-${var.env_name}"
+  sql_database_name             = var.sql_database_name != "" ? var.sql_database_name : "${var.project_name}-${var.env_name}"
+
+  # NSG locals
+  subnet_network_security_groups = {
+    for subnet_name in keys(var.subnets) :
+    subnet_name => {
+      name           = "nsg-${var.project_name}-${var.env_name}-${subnet_name}"
+      security_rules = lookup(var.subnet_network_security_rules, subnet_name, {})
+    }
+  }
+
+  # NAT Gateway
+  nat_gateway_settings = var.enable_nat_gateway && var.nat_gateway_configuration != null ? {
+    name                     = var.nat_gateway_configuration.name
+    sku_name                 = try(var.nat_gateway_configuration.sku_name, "Standard")
+    idle_timeout_in_minutes  = try(var.nat_gateway_configuration.idle_timeout_in_minutes, 4)
+    zones                    = try(var.nat_gateway_configuration.zones, [])
+    public_ip_configurations = try(var.nat_gateway_configuration.public_ip_configurations, [])
+    public_ip_ids            = try(var.nat_gateway_configuration.public_ip_ids, [])
+    subnet_keys              = var.nat_gateway_configuration.subnet_keys
+    tags                     = try(var.nat_gateway_configuration.tags, {})
+  } : null
+
+  nat_gateway_subnet_ids = local.nat_gateway_settings != null ? [
+    for key in local.nat_gateway_settings.subnet_keys : module.network.subnet_ids[key]
+  ] : []
+
+  # VPN Gateway
+  vpn_gateway_settings = var.enable_vpn_gateway && var.vpn_gateway_configuration != null ? {
+    name                     = var.vpn_gateway_configuration.name
+    gateway_subnet_key       = var.vpn_gateway_configuration.gateway_subnet_key
+    sku                      = var.vpn_gateway_configuration.sku
+    gateway_type             = try(var.vpn_gateway_configuration.gateway_type, "Vpn")
+    vpn_type                 = try(var.vpn_gateway_configuration.vpn_type, "RouteBased")
+    active_active            = try(var.vpn_gateway_configuration.active_active, false)
+    enable_bgp               = try(var.vpn_gateway_configuration.enable_bgp, false)
+    generation               = try(var.vpn_gateway_configuration.generation, null)
+    ip_configuration_name    = try(var.vpn_gateway_configuration.ip_configuration_name, "default")
+    custom_routes            = try(var.vpn_gateway_configuration.custom_routes, [])
+    public_ip                = try(var.vpn_gateway_configuration.public_ip, null)
+    public_ip_id             = try(var.vpn_gateway_configuration.public_ip_id, null)
+    vpn_client_configuration = try(var.vpn_gateway_configuration.vpn_client_configuration, null)
+    bgp_settings             = try(var.vpn_gateway_configuration.bgp_settings, null)
+    tags                     = try(var.vpn_gateway_configuration.tags, {})
+  } : null
+
+  vpn_gateway_subnet_id = local.vpn_gateway_settings != null ? module.network.subnet_ids[local.vpn_gateway_settings.gateway_subnet_key] : null
+
+  # Private Endpoints
+  kv_private_endpoint_subnet_id = var.enable_kv_private_endpoint && var.kv_private_endpoint_subnet_key != null && var.kv_private_endpoint_subnet_key != "" ? lookup(module.network.subnet_ids, var.kv_private_endpoint_subnet_key, null) : null
+  kv_private_endpoints = local.kv_private_endpoint_subnet_id != null ? [{ subnet_id = local.kv_private_endpoint_subnet_id }] : []
+
+  storage_private_endpoint_subnet_id = var.enable_storage_private_endpoint && var.storage_private_endpoint_subnet_key != null && var.storage_private_endpoint_subnet_key != "" ? lookup(module.network.subnet_ids, var.storage_private_endpoint_subnet_key, null) : null
+  storage_private_endpoints = local.storage_private_endpoint_subnet_id != null ? [{ subnet_id = local.storage_private_endpoint_subnet_id }] : []
+}
+
+# -------------------------
+# Core modules
+# -------------------------
+module "resource_group" {
+  source   = "../../Azure/modules/resource-group"
+  name     = local.rg_name
+  location = var.location
+  tags     = var.tags
+}
+
+module "app_insights" {
+  source                           = "../../Azure/modules/app-insights"
+  resource_group_name              = module.resource_group.name
+  location                         = var.location
+  log_analytics_workspace_name     = local.log_name
+  application_insights_name        = local.appi_name
+  log_analytics_retention_in_days  = var.log_analytics_retention_in_days
+  log_analytics_daily_quota_gb     = var.log_analytics_daily_quota_gb
+  tags                             = var.tags
+}
+
+module "network" {
+  source              = "../../Azure/modules/network"
+  name                = "vnet-${var.project_name}-${var.env_name}"
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  address_space       = var.vnet_address_space
+  dns_servers         = var.vnet_dns_servers
+  subnets             = var.subnets
+  tags                = var.tags
+}
+
+module "network_security_groups" {
+  for_each            = local.subnet_network_security_groups
+  source              = "../../Azure/modules/network-security-group"
+  name                = each.value.name
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  security_rules      = each.value.security_rules
+  subnet_ids          = toset([module.network.subnet_ids[each.key]])
+}
+
+module "kv" {
+  source                        = "../../Azure/modules/key-vault"
+  name                          = local.kv_name
+  resource_group_name           = module.resource_group.name
+  location                      = var.location
+  public_network_access_enabled = var.kv_public_network_access
+  network_acls                  = var.kv_network_acls
+  private_endpoints             = local.kv_private_endpoints
+  tags                          = var.tags
+}
+
+module "sql_serverless" {
+  source                         = "../../Azure/modules/sql-serverless"
+  server_name                    = local.sql_server_name
+  database_name                  = local.sql_database_name
+  resource_group_name            = module.resource_group.name
+  location                       = var.location
+  administrator_login            = var.sql_admin_login
+  administrator_password         = var.sql_admin_password
+  public_network_access_enabled  = var.sql_public_network_access
+  sku_name                       = var.sql_sku_name
+  max_size_gb                    = var.sql_max_size_gb
+  auto_pause_delay_in_minutes    = var.sql_auto_pause_delay
+  min_capacity                   = var.sql_min_capacity
+  max_capacity                   = var.sql_max_capacity
+  firewall_rules                 = var.sql_firewall_rules
+  tags                           = var.tags
+}
+
+module "kv_private_endpoint" {
+  count = var.enable_kv_private_endpoint && local.kv_private_endpoint_subnet_id != null && coalesce(var.kv_private_endpoint_resource_id, module.kv.id) != null ? 1 : 0
+  source              = "../../Azure/modules/private-endpoint"
+  name                = local.kv_private_endpoint_name
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  subnet_id           = local.kv_private_endpoint_subnet_id
+  tags                = var.tags
+
+  private_service_connection = {
+    name                           = "kv-${var.project_name}-${var.env_name}"
+    private_connection_resource_id = coalesce(var.kv_private_endpoint_resource_id, module.kv.id)
+    subresource_names              = ["vault"]
+  }
+
+  private_dns_zone_groups = length(var.kv_private_dns_zone_ids) > 0 ? [{
+    name                 = "default"
+    private_dns_zone_ids = var.kv_private_dns_zone_ids
+  }] : []
+}
+
+module "storage_private_endpoint" {
+  count = var.enable_storage_private_endpoint && local.storage_private_endpoint_subnet_id != null && var.storage_account_private_connection_resource_id != null ? 1 : 0
+  source              = "../../Azure/modules/private-endpoint"
+  name                = local.storage_private_endpoint_name
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  subnet_id           = local.storage_private_endpoint_subnet_id
+  tags                = var.tags
+
+  private_service_connection = {
+    name                           = "st-${var.project_name}-${var.env_name}"
+    private_connection_resource_id = var.storage_account_private_connection_resource_id
+    subresource_names              = var.storage_private_endpoint_subresource_names
+  }
+
+  private_dns_zone_groups = length(var.storage_private_dns_zone_ids) > 0 ? [{
+    name                 = "default"
+    private_dns_zone_ids = var.storage_private_dns_zone_ids
+  }] : []
+}
+
+# App Services
+module "app_service_web" {
+  source = "../../Azure/modules/app-service-web"
+
+  name                = local.app_service_name
+  plan_name           = local.app_service_plan_name
+  plan_sku            = var.app_service_plan_sku
+  resource_group_name = module.resource_group.name
+  location            = var.location
+
+  dotnet_version                  = var.app_service_dotnet_version
+  app_insights_connection_string = var.app_service_app_insights_connection_string
+  log_analytics_workspace_id     = var.app_service_log_analytics_workspace_id
+  app_settings                   = var.app_service_app_settings
+  connection_stri_

--- a/platform/infra/envs/qa/principal.auto.tfvars.sample
+++ b/platform/infra/envs/qa/principal.auto.tfvars.sample
@@ -1,0 +1,4 @@
+# Sample: ADO pipeline principal Object ID for qa
+# Rename this file to "principal.auto.tfvars" (or pass via pipeline variable: KV_CICD_PRINCIPAL_ID_QA)
+# Then uncomment the RBAC block in qa/main.tf to grant "Key Vault Secrets User" on the vault.
+kv_cicd_principal_id = "11111111-1111-1111-1111-111111111111"

--- a/platform/infra/envs/qa/providers.tf
+++ b/platform/infra/envs/qa/providers.tf
@@ -1,0 +1,17 @@
+locals {
+  provider_subscription_id = try(trimspace(var.subscription_id), "") != "" ? var.subscription_id : null
+  provider_tenant_id       = try(trimspace(var.tenant_id), "") != "" ? var.tenant_id : null
+}
+
+provider "azurerm" {
+  features {}
+
+  subscription_id = local.provider_subscription_id
+  tenant_id       = local.provider_tenant_id
+}
+
+provider "azuread" {
+  tenant_id = local.provider_tenant_id
+}
+
+provider "random" {}

--- a/platform/infra/envs/qa/variables.tf
+++ b/platform/infra/envs/qa/variables.tf
@@ -1,0 +1,657 @@
+# -------------------------
+# General settings
+# -------------------------
+variable "project_name" {
+  description = "Short name of the project used when constructing resource names."
+  type        = string
+}
+
+variable "env_name" {
+  description = "Name of the deployment environment (e.g. dev, stage, prod)."
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region where resources will be deployed."
+  type        = string
+}
+
+variable "tags" {
+  description = "Common tags applied to all resources."
+  type        = map(string)
+  default     = {}
+}
+
+# -------------------------
+# Monitoring
+# -------------------------
+
+variable "log_analytics_workspace_name" {
+  description = "Name assigned to the Log Analytics workspace for this environment."
+  type        = string
+}
+
+variable "application_insights_name" {
+  description = "Name assigned to the Application Insights resource for this environment."
+  type        = string
+}
+
+variable "log_analytics_retention_in_days" {
+  description = "Number of days to retain data within the Log Analytics workspace."
+  type        = number
+}
+
+variable "log_analytics_daily_quota_gb" {
+  description = "Daily ingestion quota, in GB, for the Log Analytics workspace (-1 for unlimited)."
+  type        = number
+}
+
+variable "kv_cicd_principal_id" {
+  description = "Optional object ID for the CI/CD principal that needs access to Key Vault secrets."
+  type        = string
+  default     = null
+}
+
+variable "subscription_id" {
+  description = "Optional Azure subscription ID override when the authenticated context differs from the desired target."
+  type        = string
+  default     = null
+}
+
+variable "tenant_id" {
+  description = "Optional Azure AD tenant ID override when the authenticated context differs from the desired target."
+  type        = string
+  default     = null
+}
+
+# -------------------------
+# Application Gateway
+# -------------------------
+variable "app_gateway_subnet_key" {
+  description = "Key referencing the subnet used by the Application Gateway when selecting from the virtual network map."
+  type        = string
+  default     = null
+}
+
+variable "app_gateway_subnet_id" {
+  description = "Resource ID of the subnet used by the Application Gateway when referencing an existing subnet directly."
+  type        = string
+  default     = null
+}
+
+variable "app_gateway_fqdn_prefix" {
+  description = "Prefix applied to DNS names associated with the Application Gateway."
+  type        = string
+  default     = null
+}
+
+variable "app_gateway_backend_fqdns" {
+  description = "List of backend FQDNs configured on the Application Gateway."
+  type        = list(string)
+  default     = []
+}
+
+# -------------------------
+# DNS
+# -------------------------
+variable "dns_zone_name" {
+  description = "Name of the DNS zone hosting environment-specific records."
+  type        = string
+  default     = null
+}
+
+variable "dns_a_records" {
+  description = "Map of DNS A record definitions keyed by record name."
+  type = map(object({
+    ttl     = number
+    records = list(string)
+  }))
+  default = {}
+}
+
+variable "dns_cname_records" {
+  description = "Map of DNS CNAME record definitions keyed by record name."
+  type = map(object({
+    ttl    = number
+    record = string
+  }))
+  default = {}
+}
+
+# -------------------------
+# App Service
+# -------------------------
+variable "app_service_plan_sku" {
+  description = "SKU assigned to the App Service plan hosting the web applications."
+  type        = string
+  default     = null
+}
+
+variable "app_service_fqdn_prefix" {
+  description = "Prefix used when composing the primary hostname for the web application."
+  type        = string
+  default     = null
+}
+
+variable "app_service_app_settings" {
+  description = "Application settings applied to the App Service instance."
+  type        = map(string)
+  default     = {}
+}
+
+variable "app_service_connection_strings" {
+  description = "Connection string definitions applied to the App Service instance."
+  type = map(object({
+    type  = string
+    value = string
+  }))
+  default = {}
+}
+
+# -------------------------
+# Arbitration App
+# -------------------------
+variable "arbitration_app_settings" {
+  description = "Application settings applied to the arbitration App Service instance."
+  type        = map(string)
+  default     = {}
+}
+
+# -------------------------
+# SQL Database
+# -------------------------
+variable "sql_database_name" {
+  description = "Name of the SQL database to deploy or reference."
+  type        = string
+  default     = ""
+}
+
+variable "sql_sku_name" {
+  description = "SKU name applied to the SQL database or elastic pool."
+  type        = string
+  default     = null
+}
+
+variable "sql_max_size_gb" {
+  description = "Maximum size in gigabytes allocated to the SQL database."
+  type        = number
+  default     = null
+}
+
+variable "sql_auto_pause_delay" {
+  description = "Auto-pause delay in minutes for serverless SQL configurations."
+  type        = number
+  default     = null
+}
+
+variable "sql_min_capacity" {
+  description = "Minimum compute capacity (vCores) allocated for serverless SQL databases."
+  type        = number
+  default     = null
+}
+
+variable "sql_max_capacity" {
+  description = "Maximum compute capacity (vCores) allocated for serverless SQL databases."
+  type        = number
+  default     = null
+}
+
+variable "sql_public_network_access" {
+  description = "Flag controlling public network access to the SQL server."
+  type        = bool
+  default     = true
+}
+
+variable "sql_firewall_rules" {
+  description = "List of firewall rule definitions to apply to the SQL server."
+  type = list(object({
+    name             = string
+    start_ip_address = string
+    end_ip_address   = string
+  }))
+  default = []
+}
+
+# -------------------------
+# Bastion
+# -------------------------
+variable "enable_bastion" {
+  description = "Flag to deploy an Azure Bastion host."
+  type        = bool
+  default     = false
+}
+
+variable "bastion_subnet_key" {
+  description = "Key of the subnet reserved for the Bastion host."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.enable_bastion == false || try(trimspace(var.bastion_subnet_key), "") != ""
+    error_message = "bastion_subnet_key must be provided when enable_bastion is true."
+  }
+}
+
+# -------------------------
+# Connectivity
+# -------------------------
+variable "enable_nat_gateway" {
+  description = "Flag to deploy a NAT Gateway for outbound connectivity."
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = var.enable_nat_gateway == false || var.nat_gateway_configuration != null
+    error_message = "nat_gateway_configuration must be provided when enable_nat_gateway is true."
+  }
+}
+
+variable "nat_gateway_configuration" {
+  description = "Configuration for the NAT Gateway when enabled."
+  type = object({
+    name                     = string
+    subnet_keys              = list(string)
+    public_ip_configurations = optional(list(object({
+      name              = string
+      allocation_method = optional(string, "Static")
+      sku               = optional(string, "Standard")
+      zones             = optional(list(string), [])
+      tags              = optional(map(string), {})
+    })), [])
+    public_ip_ids           = optional(list(string), [])
+    sku_name                = optional(string, "Standard")
+    idle_timeout_in_minutes = optional(number, 4)
+    zones                   = optional(list(string), [])
+    tags                    = optional(map(string), {})
+  })
+  default = null
+
+  validation {
+    condition = var.nat_gateway_configuration == null ? true : (
+      length(try(var.nat_gateway_configuration.public_ip_configurations, [])) +
+      length(try(var.nat_gateway_configuration.public_ip_ids, []))
+    ) > 0
+    error_message = "At least one public IP configuration or existing public IP ID must be provided for the NAT Gateway."
+  }
+
+  validation {
+    condition     = var.nat_gateway_configuration == null ? true : length(var.nat_gateway_configuration.subnet_keys) > 0
+    error_message = "At least one subnet key must be provided to associate the NAT Gateway."
+  }
+}
+
+variable "enable_vpn_gateway" {
+  description = "Flag to deploy a virtual network gateway for hybrid connectivity."
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = var.enable_vpn_gateway == false || var.vpn_gateway_configuration != null
+    error_message = "vpn_gateway_configuration must be provided when enable_vpn_gateway is true."
+  }
+}
+
+variable "vpn_gateway_configuration" {
+  description = "Configuration for the virtual network gateway when enabled."
+  type = object({
+    name                 = string
+    gateway_subnet_key   = string
+    sku                  = string
+    gateway_type         = optional(string, "Vpn")
+    vpn_type             = optional(string, "RouteBased")
+    active_active        = optional(bool, false)
+    enable_bgp           = optional(bool, false)
+    generation           = optional(string)
+    ip_configuration_name = optional(string, "default")
+    custom_routes        = optional(list(string), [])
+    public_ip = optional(object({
+      name              = string
+      allocation_method = optional(string, "Static")
+      sku               = optional(string, "Standard")
+      zones             = optional(list(string), [])
+      tags              = optional(map(string), {})
+    }))
+    public_ip_id            = optional(string)
+    vpn_client_configuration = optional(object({
+      address_space         = list(string)
+      vpn_client_protocols  = optional(list(string), ["OpenVPN"])
+      vpn_auth_types        = optional(list(string), [])
+      aad_tenant            = optional(string)
+      aad_audience          = optional(string)
+      aad_issuer            = optional(string)
+      radius_server_address = optional(string)
+      radius_server_secret  = optional(string)
+      root_certificates = optional(list(object({
+        name             = string
+        public_cert_data = string
+      })), [])
+      revoked_certificates = optional(list(object({
+        name       = string
+        thumbprint = string
+      })), [])
+    }))
+    bgp_settings = optional(object({
+      asn         = number
+      peer_weight = optional(number)
+      peering_addresses = optional(list(object({
+        ip_configuration_name = string
+        apipa_addresses       = list(string)
+      })), [])
+    }))
+    tags = optional(map(string), {})
+  })
+  default = null
+
+  validation {
+    condition = var.vpn_gateway_configuration == null ? true : (
+      (try(var.vpn_gateway_configuration.public_ip, null) != null ? 1 : 0) +
+      (try(var.vpn_gateway_configuration.public_ip_id, null) != null && try(trim(var.vpn_gateway_configuration.public_ip_id), "") != "" ? 1 : 0)
+    ) > 0
+    error_message = "Either a public_ip definition or public_ip_id must be supplied for the virtual network gateway."
+  }
+}
+
+# -------------------------
+# Key Vault
+# -------------------------
+variable "kv_public_network_access" {
+  description = "Allow public network access to the Key Vault."
+  type        = bool
+  default     = true
+}
+
+variable "kv_network_acls" {
+  description = "Optional network ACL configuration for the Key Vault."
+  type = object({
+    bypass                     = optional(string)
+    default_action             = optional(string)
+    ip_rules                   = optional(list(string))
+    virtual_network_subnet_ids = optional(list(string))
+  })
+  default = null
+}
+
+variable "enable_kv_private_endpoint" {
+  description = "Toggle creation of a private endpoint for the Key Vault."
+  type        = bool
+  default     = false
+}
+
+variable "kv_private_endpoint_subnet_key" {
+  description = "Subnet key used when creating the Key Vault private endpoint."
+  type        = string
+  default     = null
+}
+
+variable "kv_private_dns_zone_ids" {
+  description = "Private DNS zone IDs linked to the Key Vault private endpoint."
+  type        = list(string)
+  default     = []
+}
+
+variable "kv_private_endpoint_resource_id" {
+  description = "Override resource ID supplied to the Key Vault private endpoint module."
+  type        = string
+  default     = null
+}
+
+# -------------------------
+# Storage
+# -------------------------
+variable "enable_storage_private_endpoint" {
+  description = "Toggle creation of a private endpoint for the storage account."
+  type        = bool
+  default     = false
+}
+
+variable "storage_private_endpoint_subnet_key" {
+  description = "Subnet key used when creating the storage account private endpoint."
+  type        = string
+  default     = null
+}
+
+variable "storage_private_dns_zone_ids" {
+  description = "Private DNS zone IDs linked to the storage account private endpoint."
+  type        = list(string)
+  default     = []
+}
+
+variable "storage_private_endpoint_subresource_names" {
+  description = "Subresource names exposed through the storage account private endpoint."
+  type        = list(string)
+  default     = ["blob"]
+}
+
+variable "storage_account_private_connection_resource_id" {
+  description = "Resource ID used by the storage account private endpoint connection."
+  type        = string
+  default     = null
+}
+
+# -------------------------
+# App Services
+# -------------------------
+
+variable "app_service_plan_sku" {
+  description = "SKU for the App Service plan hosting the primary web application."
+  type        = string
+  default     = "B1"
+}
+
+variable "app_service_dotnet_version" {
+  description = ".NET runtime version for the primary web application."
+  type        = string
+  default     = "8.0"
+}
+
+variable "app_service_app_insights_connection_string" {
+  description = "Application Insights connection string injected into the primary web app."
+  type        = string
+
+  validation {
+    condition     = try(trimspace(var.app_service_app_insights_connection_string), "") != ""
+    error_message = "app_service_app_insights_connection_string must be provided when deploying the web app."
+  }
+}
+
+variable "app_service_log_analytics_workspace_id" {
+  description = "Optional Log Analytics workspace resource ID for App Service diagnostics."
+  type        = string
+  default     = null
+}
+
+variable "app_service_app_settings" {
+  description = "Additional application settings applied to the primary web app."
+  type        = map(string)
+  default     = {}
+}
+
+variable "app_service_connection_strings" {
+  description = "Connection strings exposed to the primary web application."
+  type = map(object({
+    type  = string
+    value = string
+  }))
+  default = {}
+}
+
+variable "enable_arbitration_app_service" {
+  description = "Toggle deployment of the arbitration App Service."
+  type        = bool
+  default     = false
+}
+
+variable "arbitration_app_plan_sku" {
+  description = "Optional SKU override for the arbitration App Service plan."
+  type        = string
+  default     = null
+}
+
+variable "arbitration_runtime_stack" {
+  description = "Runtime stack for the arbitration App Service."
+  type        = string
+  default     = "dotnet"
+}
+
+variable "arbitration_runtime_version" {
+  description = "Runtime version for the arbitration App Service."
+  type        = string
+  default     = "8.0"
+}
+
+variable "arbitration_app_insights_connection_string" {
+  description = "Optional Application Insights connection string for the arbitration app (defaults to the primary web app string)."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.arbitration_app_insights_connection_string == null || trimspace(var.arbitration_app_insights_connection_string) != ""
+    error_message = "arbitration_app_insights_connection_string cannot be blank; omit it to reuse the primary web app setting."
+  }
+}
+
+variable "arbitration_log_analytics_workspace_id" {
+  description = "Optional Log Analytics workspace resource ID dedicated to the arbitration app."
+  type        = string
+  default     = null
+}
+
+variable "arbitration_app_settings" {
+  description = "Application settings applied to the arbitration App Service."
+  type        = map(string)
+  default     = {}
+}
+
+variable "arbitration_connection_strings" {
+  description = "Connection strings exposed to the arbitration App Service."
+  type = map(object({
+    type  = string
+    value = string
+  }))
+  default = {}
+}
+
+variable "arbitration_run_from_package" {
+  description = "Flag controlling WEBSITE_RUN_FROM_PACKAGE for the arbitration App Service."
+  type        = bool
+  default     = true
+}
+
+# -------------------------
+# Networking
+# -------------------------
+variable "vnet_address_space" {
+  description = "Address space assigned to the virtual network."
+  type        = list(string)
+}
+
+variable "vnet_dns_servers" {
+  description = "Optional custom DNS servers applied to the virtual network."
+  type        = list(string)
+  default     = []
+}
+
+variable "subnets" {
+  description = "Map of subnet definitions keyed by subnet name."
+  type = map(object({
+    address_prefixes  = list(string)
+    service_endpoints = optional(list(string), [])
+    delegations = optional(list(object({
+      name = string
+      service_delegation = object({
+        name    = string
+        actions = list(string)
+      })
+    })), [])
+  }))
+}
+
+variable "subnet_network_security_rules" {
+  description = <<-DOC
+  Map of network security rule sets keyed by subnet name. Each entry should
+  match the `security_rules` input for the `network-security-group` module and
+  defaults to an empty map, resulting in only the built-in Azure NSG rules.
+  DOC
+  type = map(map(object({
+    priority                     = number
+    direction                    = optional(string, "Inbound")
+    access                       = optional(string, "Allow")
+    protocol                     = optional(string, "*")
+    source_port_range            = optional(string)
+    source_port_ranges           = optional(list(string))
+    destination_port_range       = optional(string)
+    destination_port_ranges      = optional(list(string))
+    source_address_prefix        = optional(string)
+    source_address_prefixes      = optional(list(string))
+    destination_address_prefix   = optional(string)
+    destination_address_prefixes = optional(list(string))
+    description                  = optional(string)
+  })))
+  default = {}
+}
+
+# -------------------------
+# SQL Database
+# -------------------------
+variable "sql_database_name" {
+  description = "Optional override for the SQL database name. Defaults to <project>-<env> when blank."
+  type        = string
+  default     = ""
+}
+
+variable "sql_admin_login" {
+  description = "Administrator login for the SQL server. Provide securely via pipeline variables or Key Vault."
+  type        = string
+}
+
+variable "sql_admin_password" {
+  description = "Administrator password for the SQL server. Provide securely via pipeline variables or Key Vault."
+  type        = string
+  sensitive   = true
+}
+
+variable "sql_sku_name" {
+  description = "SKU name for the serverless SQL database (for example GP_S_Gen5_2)."
+  type        = string
+  default     = "GP_S_Gen5_2"
+}
+
+variable "sql_max_size_gb" {
+  description = "Maximum size of the SQL database in gigabytes."
+  type        = number
+  default     = 75
+}
+
+variable "sql_auto_pause_delay" {
+  description = "Number of minutes before the serverless database auto pauses. Use -1 to disable."
+  type        = number
+  default     = 60
+}
+
+variable "sql_min_capacity" {
+  description = "Minimum vCore capacity for the serverless database."
+  type        = number
+  default     = 0.5
+}
+
+variable "sql_max_capacity" {
+  description = "Maximum vCore capacity for the serverless database."
+  type        = number
+  default     = 4
+}
+
+variable "sql_public_network_access" {
+  description = "Whether public network access is enabled for the SQL server."
+  type        = bool
+  default     = true
+}
+
+variable "sql_firewall_rules" {
+  description = "List of firewall rules to apply to the SQL server."
+  type = list(object({
+    name             = string
+    start_ip_address = string
+    end_ip_address   = string
+  }))
+  default = []
+}

--- a/platform/infra/envs/qa/versions.tf
+++ b/platform/infra/envs/qa/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~>4.33" }
+    azuread = { source = "hashicorp/azuread", version = "~>2.40" }
+    random  = { source = "hashicorp/random",  version = "~>3.5" }
+  }
+}

--- a/scripts/azure-bootstrap-tfstate.ps1
+++ b/scripts/azure-bootstrap-tfstate.ps1
@@ -9,7 +9,7 @@ az account set --subscription $SubscriptionId | Out-Null
 az group create -n $ResourceGroup -l $Location -o none | Out-Null
 az storage account create -g $ResourceGroup -n $StorageAcct -l $Location --sku Standard_LRS --kind StorageV2 --min-tls-version TLS1_2 --allow-blob-public-access false -o none | Out-Null
 $Key = az storage account keys list -g $ResourceGroup -n $StorageAcct --query "[0].value" -o tsv
-foreach ($env in @('dev', 'stage', 'prod')) {
+foreach ($env in @('dev', 'qa', 'stage', 'prod')) {
   az storage container create --name "$ContainerPrefix-$env" --account-name $StorageAcct --account-key $Key -o none | Out-Null
 }
 Write-Host "backend.tfvars -> rg=$ResourceGroup sa=$StorageAcct container=$ContainerPrefix-<env> key=<env>-specific-state-key use_azuread_auth=true"

--- a/scripts/azure-bootstrap-tfstate.sh
+++ b/scripts/azure-bootstrap-tfstate.sh
@@ -5,7 +5,7 @@ az account set --subscription "$SUB"
 az group create -n "$RG" -l "$LOC" -o none
 az storage account create -g "$RG" -n "$SA" -l "$LOC" --sku Standard_LRS --kind StorageV2 --min-tls-version TLS1_2 --allow-blob-public-access false -o none
 KEY=$(az storage account keys list -g "$RG" -n "$SA" --query "[0].value" -o tsv)
-for ENV in dev stage prod; do
+for ENV in dev qa stage prod; do
   az storage container create --name "${CN_PREFIX}-${ENV}" --account-name "$SA" --account-key "$KEY" -o none
 done
 echo "backend.tfvars -> rg=$RG sa=$SA container=${CN_PREFIX}-<env> key=<env>-specific-state-key use_azuread_auth=true"


### PR DESCRIPTION
## Summary
- add a dedicated `qa` Terraform root cloned from `dev` with QA-specific backend, networking, and secret references
- update infrastructure and application Azure Pipelines plus bootstrap scripts to plan/apply and deploy QA alongside existing environments
- refresh documentation to reference the new QA environment throughout setup and workflow guides

## Testing
- not run (terraform CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c995bf77908326ae948324218859fe