### PR TITLE
Add deployment scripts for MPArbitration app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ override.tf.json
 
 # OS metadata
 .DS_Store
+
+# Build outputs
+artifacts/

--- a/README.md
+++ b/README.md
@@ -77,8 +77,11 @@ arbit-consolidated-infra-ado/
 │           ├── stage/                 # Same structure as dev
 │           └── prod/                  # Same structure as dev
 ├── scripts/
+│   ├── Arbitration-SendNSARequests.ps1 # Sample script for NSA API interactions
 │   ├── azure-bootstrap-tfstate.ps1    # Bootstrap Terraform state resources (PowerShell)
-│   └── azure-bootstrap-tfstate.sh     # Bootstrap Terraform state resources (Bash)
+│   ├── azure-bootstrap-tfstate.sh     # Bootstrap Terraform state resources (Bash)
+│   ├── deploy-arbitration.ps1         # Build, package, and deploy MPArbitration via Azure CLI (PowerShell)
+│   └── deploy-arbitration.sh          # Bash equivalent for Linux/macOS agents
 ├── docs/
 │   ├── ADO-setup.md                   # Detailed ADO onboarding
 │   ├── step-by-step.md                # First-run walkthrough
@@ -171,6 +174,72 @@ arbit-consolidated-infra-ado/
 | `Backend not found` | Incorrect names in `backend.tfvars` | Update resource group/storage/container values to match reality. |
 | Provider version errors | Agent using wrong Terraform/provider versions | Keep `TF_VERSION` pinned; rerun with `terraform init -reconfigure`. |
 | OIDC login fails | Federated credential misconfigured | Recreate the service connection with workload identity federation and correct project/repo mapping. |
+
+## MPArbitration deployment helpers
+
+Cross-platform deployment scripts live under `scripts/` to mirror the manual build/package steps that run in CI. They restore the .NET solution, build the Angular client with an environment-specific configuration, publish the app, zip the output, and push it to App Service using `az webapp deploy` (or `--use-zip-deploy` for the legacy ZIP push command).
+
+### Prerequisites
+
+- [.NET SDK 6.0](global.json) to match the solution requirements.
+- Node.js 16.x (same version as the pipeline) for the Angular build.
+- Azure CLI authenticated against the target subscription (`az login` / `az account set`).
+- `zip` installed when using the Bash script on Linux/macOS agents.
+
+Artifacts are dropped in `artifacts/arbitration/<environment>` (ignored by Git). The `-Environment`/`--environment` switch selects the Angular build profile (`dev → npm run build-dev`, `stage → npm run build-stage`, all others → production `npm run build`).
+
+### PowerShell (Windows/PowerShell Core)
+
+```powershell
+pwsh ./scripts/deploy-arbitration.ps1 \`
+  -ResourceGroup rg-arbit-dev \`
+  -AppName mp-arbit-dev \`
+  -Environment dev \`
+  -Configuration Release \`
+  -Slot dev
+```
+
+Omit optional parameters as needed. Pass `-OutputDirectory` to change the artifact drop location or `-UseZipDeploy` to call `az webapp deployment source config-zip` instead of the newer `az webapp deploy` command.
+
+### Bash (Linux/macOS)
+
+```bash
+./scripts/deploy-arbitration.sh \
+  --resource-group rg-arbit-dev \
+  --app-name mp-arbit-dev \
+  --environment dev \
+  --configuration Release
+```
+
+Make the script executable once with `chmod +x scripts/deploy-arbitration.sh`. Supply `--slot` or `--use-zip-deploy` when you need to target a deployment slot or the legacy ZIP push workflow.
+
+### Azure Pipelines integration example
+
+```yaml
+- stage: Deploy_Arbitration_Dev
+  displayName: Deploy MPArbitration (dev)
+  dependsOn: Apply_Dev
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  jobs:
+  - job: deploy_app
+    displayName: Run deploy-arbitration.sh
+    pool: { vmImage: 'ubuntu-latest' }
+    steps:
+    - checkout: self
+    - task: AzureCLI@2
+      displayName: Deploy MPArbitration ZIP
+      inputs:
+        azureSubscription: sc-azure-oidc-dev
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          ./scripts/deploy-arbitration.sh \
+            --resource-group rg-arbit-dev \
+            --app-name mp-arbit-dev \
+            --environment dev
+```
+
+Swap in the PowerShell script when running on a Windows agent (`scriptType: pscore` + `scriptPath: scripts/deploy-arbitration.ps1`). Reuse the same stage structure for stage/prod slots or dedicated App Service instances.
 
 ---
 

--- a/scripts/deploy-arbitration.ps1
+++ b/scripts/deploy-arbitration.ps1
@@ -1,0 +1,131 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)] [string] $ResourceGroup,
+    [Parameter(Mandatory=$true)] [string] $AppName,
+    [Parameter(Mandatory=$true)] [string] $Environment,
+    [string] $Configuration = 'Release',
+    [string] $OutputDirectory,
+    [string] $Slot,
+    [switch] $UseZipDeploy
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$ResourceGroup = $ResourceGroup.Trim()
+$AppName = $AppName.Trim()
+$Environment = $Environment.Trim()
+if ($PSBoundParameters.ContainsKey('Configuration')) {
+    $Configuration = $Configuration.Trim()
+    if ([string]::IsNullOrWhiteSpace($Configuration)) {
+        $Configuration = 'Release'
+    }
+}
+if ($Slot) {
+    $Slot = $Slot.Trim()
+    if ([string]::IsNullOrWhiteSpace($Slot)) {
+        $Slot = $null
+    }
+}
+if ($OutputDirectory) {
+    $OutputDirectory = $OutputDirectory.Trim()
+    if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+        $OutputDirectory = $null
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($ResourceGroup)) {
+    throw 'Resource group is required.'
+}
+
+if ([string]::IsNullOrWhiteSpace($AppName)) {
+    throw 'App Service name is required.'
+}
+
+if ([string]::IsNullOrWhiteSpace($Environment)) {
+    throw 'Environment name is required.'
+}
+
+if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+    throw 'dotnet CLI is required but was not found on PATH.'
+}
+
+if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+    throw 'Azure CLI (az) is required but was not found on PATH.'
+}
+
+if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+    throw 'Node.js (npm) is required but was not found on PATH.'
+}
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$solutionPath = Join-Path $repoRoot 'Arbitration/MPArbitration.sln'
+$clientAppPath = Join-Path $repoRoot 'Arbitration/MPArbitration/ClientApp'
+
+if (-not (Test-Path $solutionPath)) {
+    throw "Solution not found at $solutionPath"
+}
+
+if (-not (Test-Path $clientAppPath)) {
+    throw "Client app folder not found at $clientAppPath"
+}
+
+$artifactRoot = if ($OutputDirectory) {
+    if (-not (Test-Path $OutputDirectory)) {
+        New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
+    }
+    (Resolve-Path -Path $OutputDirectory).Path
+} else {
+    $defaultPath = Join-Path $repoRoot "artifacts/arbitration/$Environment"
+    New-Item -ItemType Directory -Path $defaultPath -Force | Out-Null
+    (Resolve-Path -Path $defaultPath).Path
+}
+
+$publishDir = Join-Path $artifactRoot 'publish'
+if (Test-Path $publishDir) {
+    Remove-Item -Path $publishDir -Recurse -Force
+}
+New-Item -ItemType Directory -Path $publishDir -Force | Out-Null
+
+Write-Host "Restoring .NET solution..."
+dotnet restore $solutionPath --nologo
+
+Write-Host "Installing client dependencies..."
+npm ci --prefix $clientAppPath
+
+$clientBuildScript = switch -Regex ($Environment.ToLowerInvariant()) {
+    '^dev(elopment)?$'   { 'build-dev'; break }
+    '^stage(ing)?$'     { 'build-stage'; break }
+    '^prod(uction)?$'   { 'build'; break }
+    default             { 'build'; break }
+}
+
+Write-Host "Building client app using 'npm run $clientBuildScript'..."
+npm run $clientBuildScript --prefix $clientAppPath
+
+Write-Host "Publishing .NET solution to $publishDir..."
+dotnet publish $solutionPath --configuration $Configuration --no-restore --output $publishDir --nologo
+
+$timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$zipPath = Join-Path $artifactRoot ("MPArbitration-$Environment-$timestamp.zip")
+if (Test-Path $zipPath) {
+    Remove-Item -Path $zipPath -Force
+}
+
+Write-Host "Packaging publish folder into $zipPath..."
+Compress-Archive -Path (Join-Path $publishDir '*') -DestinationPath $zipPath -Force
+
+$azArgs = if ($UseZipDeploy.IsPresent) {
+    $args = @('webapp', 'deployment', 'source', 'config-zip', '--resource-group', $ResourceGroup, '--name', $AppName, '--src', $zipPath)
+    if ($Slot) { $args += @('--slot', $Slot) }
+    $args
+} else {
+    $args = @('webapp', 'deploy', '--resource-group', $ResourceGroup, '--name', $AppName, '--src-path', $zipPath, '--type', 'zip')
+    if ($Slot) { $args += @('--slot', $Slot) }
+    $args
+}
+
+Write-Host "Deploying package to Azure Web App '$AppName' (resource group '$ResourceGroup')..."
+az @azArgs
+
+Write-Host "Deployment complete. Package path: $zipPath"

--- a/scripts/deploy-arbitration.sh
+++ b/scripts/deploy-arbitration.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: deploy-arbitration.sh -g <resource-group> -n <app-name> -e <environment> [options]
+
+Required arguments:
+  -g, --resource-group   Azure resource group that hosts the App Service
+  -n, --app-name         App Service name
+  -e, --environment      Environment name (dev, stage, prod, etc.)
+
+Optional arguments:
+  -c, --configuration    dotnet publish configuration (default: Release)
+  -o, --output           Output directory for build artifacts (default: ./artifacts/arbitration/<environment>)
+  -s, --slot             Deploy to a specific App Service slot
+      --use-zip-deploy   Use legacy az webapp deployment source config-zip instead of az webapp deploy
+  -h, --help             Show this help message
+USAGE
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: Required command '$1' is not available on PATH." >&2
+    exit 1
+  fi
+}
+
+trim() {
+  local var="$*"
+  var="${var#${var%%[![:space:]]*}}"
+  var="${var%${var##*[![:space:]]}}"
+  printf '%s' "$var"
+}
+
+require_command dotnet
+require_command az
+require_command npm
+require_command zip
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+RESOURCE_GROUP=""
+APP_NAME=""
+ENVIRONMENT=""
+CONFIGURATION="Release"
+OUTPUT_DIR=""
+SLOT=""
+DEPLOY_METHOD="deploy"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -g|--resource-group)
+      RESOURCE_GROUP="$2"
+      shift 2
+      ;;
+    -n|--app-name)
+      APP_NAME="$2"
+      shift 2
+      ;;
+    -e|--environment)
+      ENVIRONMENT="$2"
+      shift 2
+      ;;
+    -c|--configuration)
+      CONFIGURATION="$2"
+      shift 2
+      ;;
+    -o|--output)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    -s|--slot)
+      SLOT="$2"
+      shift 2
+      ;;
+    --use-zip-deploy)
+      DEPLOY_METHOD="zip-deploy"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+RESOURCE_GROUP="$(trim "$RESOURCE_GROUP")"
+APP_NAME="$(trim "$APP_NAME")"
+ENVIRONMENT="$(trim "$ENVIRONMENT")"
+CONFIGURATION="$(trim "$CONFIGURATION")"
+SLOT="$(trim "$SLOT")"
+OUTPUT_DIR="$(trim "$OUTPUT_DIR")"
+
+if [[ -z "$RESOURCE_GROUP" || -z "$APP_NAME" || -z "$ENVIRONMENT" ]]; then
+  echo "Error: resource group, app name, and environment are required." >&2
+  usage
+  exit 1
+fi
+
+if [[ -z "$CONFIGURATION" ]]; then
+  CONFIGURATION="Release"
+fi
+
+SOLUTION_PATH="$REPO_ROOT/Arbitration/MPArbitration.sln"
+CLIENT_APP_PATH="$REPO_ROOT/Arbitration/MPArbitration/ClientApp"
+
+if [[ ! -f "$SOLUTION_PATH" ]]; then
+  echo "Error: Solution not found at $SOLUTION_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -d "$CLIENT_APP_PATH" ]]; then
+  echo "Error: Client app folder not found at $CLIENT_APP_PATH" >&2
+  exit 1
+fi
+
+if [[ -n "$OUTPUT_DIR" ]]; then
+  mkdir -p "$OUTPUT_DIR"
+  ARTIFACT_ROOT="$(cd "$OUTPUT_DIR" && pwd)"
+else
+  ARTIFACT_ROOT="$REPO_ROOT/artifacts/arbitration/$ENVIRONMENT"
+  mkdir -p "$ARTIFACT_ROOT"
+fi
+
+PUBLISH_DIR="$ARTIFACT_ROOT/publish"
+rm -rf "$PUBLISH_DIR"
+mkdir -p "$PUBLISH_DIR"
+
+echo "Restoring .NET solution..."
+dotnet restore "$SOLUTION_PATH" --nologo
+
+echo "Installing client dependencies..."
+npm ci --prefix "$CLIENT_APP_PATH"
+
+CLIENT_BUILD_SCRIPT="build"
+case "${ENVIRONMENT,,}" in
+  dev|development)
+    CLIENT_BUILD_SCRIPT="build-dev"
+    ;;
+  stage|staging)
+    CLIENT_BUILD_SCRIPT="build-stage"
+    ;;
+  prod|production)
+    CLIENT_BUILD_SCRIPT="build"
+    ;;
+  *)
+    CLIENT_BUILD_SCRIPT="build"
+    ;;
+ esac
+
+echo "Building client app with npm run $CLIENT_BUILD_SCRIPT..."
+npm run "$CLIENT_BUILD_SCRIPT" --prefix "$CLIENT_APP_PATH"
+
+echo "Publishing .NET solution to $PUBLISH_DIR..."
+dotnet publish "$SOLUTION_PATH" --configuration "$CONFIGURATION" --no-restore --output "$PUBLISH_DIR" --nologo
+
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+ZIP_PATH="$ARTIFACT_ROOT/MPArbitration-$ENVIRONMENT-$TIMESTAMP.zip"
+rm -f "$ZIP_PATH"
+
+echo "Packaging publish folder into $ZIP_PATH..."
+(
+  cd "$PUBLISH_DIR"
+  zip -qr "$ZIP_PATH" .
+)
+
+if [[ "$DEPLOY_METHOD" == "deploy" ]]; then
+  AZ_CMD=(az webapp deploy --resource-group "$RESOURCE_GROUP" --name "$APP_NAME" --src-path "$ZIP_PATH" --type zip)
+else
+  AZ_CMD=(az webapp deployment source config-zip --resource-group "$RESOURCE_GROUP" --name "$APP_NAME" --src "$ZIP_PATH")
+fi
+
+if [[ -n "$SLOT" ]]; then
+  AZ_CMD+=(--slot "$SLOT")
+fi
+
+echo "Deploying package to Azure Web App '$APP_NAME' (resource group '$RESOURCE_GROUP')..."
+"${AZ_CMD[@]}"
+
+echo "Deployment complete. Package path: $ZIP_PATH"


### PR DESCRIPTION
## Summary
- add PowerShell and Bash helpers that restore, publish, zip, and deploy the MPArbitration solution
- document usage, prerequisites, and example pipeline integration for the deployment scripts
- ignore local build artifacts generated by the new scripts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c995c3f4208326af6c736507a1459a