### PR TITLE
Fix QA app service module block

### DIFF
--- a/platform/infra/envs/qa/main.tf
+++ b/platform/infra/envs/qa/main.tf
@@ -201,4 +201,5 @@ module "app_service_web" {
   app_insights_connection_string = var.app_service_app_insights_connection_string
   log_analytics_workspace_id     = var.app_service_log_analytics_workspace_id
   app_settings                   = var.app_service_app_settings
-  connection_stri_
+  connection_strings             = var.app_service_connection_strings
+}


### PR DESCRIPTION
## Summary
- complete the qa app_service_web module by wiring through connection strings and closing the block

## Testing
- terraform validate *(fails: terraform CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a9afba68832680c602544016a54c