### PR TITLE
Add Linux App Service wrapper module

### DIFF
--- a/platform/infra/Azure/modules/app-service-web/main.tf
+++ b/platform/infra/Azure/modules/app-service-web/main.tf
@@ -1,0 +1,90 @@
+locals {
+  app_insights_connection_string_trimmed = trimspace(coalesce(var.app_insights_connection_string, ""))
+  log_analytics_workspace_id_trimmed      = trimspace(coalesce(var.log_analytics_workspace_id, ""))
+  enable_diagnostics                      = local.log_analytics_workspace_id_trimmed != ""
+}
+
+resource "azurerm_service_plan" "this" {
+  name                = var.plan_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  os_type             = "Linux"
+  sku_name            = var.plan_sku
+  tags                = var.tags
+}
+
+resource "azurerm_linux_web_app" "this" {
+  name                = var.name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  service_plan_id     = azurerm_service_plan.this.id
+  https_only          = var.https_only
+  tags                = var.tags
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  site_config {
+    always_on  = var.always_on
+    ftps_state = var.ftps_state
+
+    application_stack {
+      dotnet_version = var.dotnet_version
+    }
+  }
+
+  app_settings = merge(
+    local.app_insights_connection_string_trimmed != "" ? {
+      "APPINSIGHTS_CONNECTION_STRING" = local.app_insights_connection_string_trimmed
+      "APPINSIGHTS_CONNECTIONSTRING"  = local.app_insights_connection_string_trimmed
+    } : {},
+    var.run_from_package ? { "WEBSITE_RUN_FROM_PACKAGE" = "1" } : {},
+    var.app_settings
+  )
+
+  dynamic "connection_string" {
+    for_each = var.connection_strings
+    content {
+      name  = connection_string.key
+      type  = connection_string.value.type
+      value = connection_string.value.value
+    }
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "this" {
+  count = local.enable_diagnostics ? 1 : 0
+
+  name                       = "${var.name}-diag"
+  target_resource_id         = azurerm_linux_web_app.this.id
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+
+  dynamic "log" {
+    for_each = [
+      "AppServiceHTTPLogs",
+      "AppServiceConsoleLogs",
+      "AppServiceAppLogs",
+      "AppServiceAuditLogs",
+      "AppServiceFileAuditLogs",
+      "AppServicePlatformLogs",
+    ]
+    content {
+      category = log.value
+      enabled  = true
+
+      retention_policy {
+        enabled = false
+      }
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+
+    retention_policy {
+      enabled = false
+    }
+  }
+}

--- a/platform/infra/Azure/modules/app-service-web/outputs.tf
+++ b/platform/infra/Azure/modules/app-service-web/outputs.tf
@@ -1,0 +1,24 @@
+output "id" {
+  description = "Resource ID of the Linux App Service."
+  value       = azurerm_linux_web_app.this.id
+}
+
+output "name" {
+  description = "Name of the Linux App Service."
+  value       = azurerm_linux_web_app.this.name
+}
+
+output "default_hostname" {
+  description = "Default hostname assigned to the Linux App Service."
+  value       = azurerm_linux_web_app.this.default_hostname
+}
+
+output "principal_id" {
+  description = "System-assigned managed identity principal ID for the App Service."
+  value       = azurerm_linux_web_app.this.identity[0].principal_id
+}
+
+output "service_plan_id" {
+  description = "Resource ID of the associated App Service plan."
+  value       = azurerm_service_plan.this.id
+}

--- a/platform/infra/Azure/modules/app-service-web/variables.tf
+++ b/platform/infra/Azure/modules/app-service-web/variables.tf
@@ -1,0 +1,86 @@
+variable "name" {
+  description = "Name of the App Service instance."
+  type        = string
+}
+
+variable "plan_name" {
+  description = "Name assigned to the App Service plan."
+  type        = string
+}
+
+variable "plan_sku" {
+  description = "SKU applied to the App Service plan (for example P1v3, S1)."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Resource group hosting the App Service resources."
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region where the App Service resources are deployed."
+  type        = string
+}
+
+variable "dotnet_version" {
+  description = ".NET runtime version applied to the Linux web app."
+  type        = string
+  default     = "8.0"
+}
+
+variable "https_only" {
+  description = "Force HTTPS traffic only for the web app."
+  type        = bool
+  default     = true
+}
+
+variable "always_on" {
+  description = "Enable the Always On setting for the web app."
+  type        = bool
+  default     = true
+}
+
+variable "ftps_state" {
+  description = "FTPS configuration for the web app."
+  type        = string
+  default     = "Disabled"
+}
+
+variable "run_from_package" {
+  description = "When true, sets WEBSITE_RUN_FROM_PACKAGE to 1."
+  type        = bool
+  default     = false
+}
+
+variable "app_insights_connection_string" {
+  description = "Application Insights connection string injected into the web app settings."
+  type        = string
+}
+
+variable "log_analytics_workspace_id" {
+  description = "Optional Log Analytics workspace resource ID used for diagnostics."
+  type        = string
+  default     = null
+}
+
+variable "app_settings" {
+  description = "Additional application settings merged into the web app configuration."
+  type        = map(string)
+  default     = {}
+}
+
+variable "connection_strings" {
+  description = "Connection string definitions exposed to the web app."
+  type = map(object({
+    type  = string
+    value = string
+  }))
+  default = {}
+}
+
+variable "tags" {
+  description = "Tags applied to created resources."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary
- add a dedicated Linux App Service wrapper module that provisions the plan, web app, and diagnostics expected by the QA environment
- expose inputs for the QA deployment (runtime version, diagnostics, connection strings, tags) and return useful resource identifiers

## Testing
- not run (terraform CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c9a9b2217c8326af72d7d4e6cfe7ed