### PR TITLE
Align env app service definitions with declared variables

### DIFF
--- a/platform/infra/envs/dev/main.tf
+++ b/platform/infra/envs/dev/main.tf
@@ -1,20 +1,25 @@
 locals {
-  normalized_runtime_stack = lower(trimspace(coalesce(var.runtime_stack, "dotnet")))
+  resource_group_name = try(trimspace(var.resource_group_name), "") != "" ? var.resource_group_name : "rg-${var.project_name}-${var.env_name}"
+  app_service_plan_name = try(trimspace(var.app_service_plan_name), "") != "" ? var.app_service_plan_name : "asp-${var.project_name}-web-${var.env_name}-${var.location}"
+  app_service_name =
+    try(trimspace(var.app_service_name), "") != "" ? var.app_service_name :
+    try(trimspace(var.app_service_fqdn_prefix), "") != "" ? var.app_service_fqdn_prefix :
+    "app-${var.project_name}-web-${var.env_name}"
 }
 
 resource "azurerm_service_plan" "plan" {
-  name                = var.plan_name
+  name                = local.app_service_plan_name
   location            = var.location
-  resource_group_name = var.resource_group_name
+  resource_group_name = local.resource_group_name
   os_type             = "Linux"
-  sku_name            = var.plan_sku
+  sku_name            = var.app_service_plan_sku
   tags                = var.tags
 }
 
 resource "azurerm_linux_web_app" "app" {
-  name                = var.name
+  name                = local.app_service_name
   location            = var.location
-  resource_group_name = var.resource_group_name
+  resource_group_name = local.resource_group_name
   service_plan_id     = azurerm_service_plan.plan.id
   https_only          = true
 
@@ -23,27 +28,25 @@ resource "azurerm_linux_web_app" "app" {
   }
 
   site_config {
-    always_on = var.always_on
+    always_on  = true
     ftps_state = "Disabled"
 
     application_stack {
-      dotnet_version = local.normalized_runtime_stack == "dotnet" ? var.runtime_version : null
-      node_version   = local.normalized_runtime_stack == "node"   ? var.runtime_version : null
-      python_version = local.normalized_runtime_stack == "python" ? var.runtime_version : null
+      dotnet_version = var.app_service_dotnet_version
     }
   }
 
   app_settings = merge(
     {
-      "APPINSIGHTS_CONNECTION_STRING" = var.app_insights_connection_string
-      "APPINSIGHTS_CONNECTIONSTRING"  = var.app_insights_connection_string
+      "APPINSIGHTS_CONNECTION_STRING" = var.app_service_app_insights_connection_string
+      "APPINSIGHTS_CONNECTIONSTRING"  = var.app_service_app_insights_connection_string
     },
-    var.run_from_package == true ? { "WEBSITE_RUN_FROM_PACKAGE" = "1" } : {},
-    var.app_settings
+    var.app_service_run_from_package ? { "WEBSITE_RUN_FROM_PACKAGE" = "1" } : {},
+    var.app_service_app_settings
   )
 
   dynamic "connection_string" {
-    for_each = var.connection_strings
+    for_each = var.app_service_connection_strings
     content {
       name  = connection_string.key
       type  = connection_string.value.type
@@ -55,11 +58,11 @@ resource "azurerm_linux_web_app" "app" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "app" {
-  count = var.log_analytics_workspace_id == null || var.log_analytics_workspace_id == "" ? 0 : 1
+  count = try(trimspace(var.app_service_log_analytics_workspace_id), "") != "" ? 1 : 0
 
-  name                       = "${var.name}-diag"
+  name                       = "${local.app_service_name}-diag"
   target_resource_id         = azurerm_linux_web_app.app.id
-  log_analytics_workspace_id = var.log_analytics_workspace_id
+  log_analytics_workspace_id = var.app_service_log_analytics_workspace_id
 
   dynamic "log" {
     for_each = [

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -121,6 +121,24 @@ variable "dns_cname_records" {
 # -------------------------
 # App Service
 # -------------------------
+variable "resource_group_name" {
+  description = "Name of the resource group hosting the App Service resources. Defaults to rg-<project>-<env> when omitted."
+  type        = string
+  default     = null
+}
+
+variable "app_service_plan_name" {
+  description = "Explicit name assigned to the App Service plan. Defaults to asp-<project>-web-<env>-<location> when unset."
+  type        = string
+  default     = null
+}
+
+variable "app_service_name" {
+  description = "Name assigned to the primary App Service. Falls back to app_service_fqdn_prefix or app-<project>-web-<env>."
+  type        = string
+  default     = null
+}
+
 variable "app_service_plan_sku" {
   description = "SKU assigned to the App Service plan hosting the web applications."
   type        = string
@@ -452,6 +470,12 @@ variable "app_service_app_insights_connection_string" {
     condition     = try(trimspace(var.app_service_app_insights_connection_string), "") != ""
     error_message = "app_service_app_insights_connection_string must be provided when deploying the web app."
   }
+}
+
+variable "app_service_run_from_package" {
+  description = "When true, sets WEBSITE_RUN_FROM_PACKAGE to 1 for the primary web app."
+  type        = bool
+  default     = true
 }
 
 variable "app_service_log_analytics_workspace_id" {

--- a/platform/infra/envs/prod/main.tf
+++ b/platform/infra/envs/prod/main.tf
@@ -1,20 +1,25 @@
 locals {
-  normalized_runtime_stack = lower(trimspace(coalesce(var.runtime_stack, "dotnet")))
+  resource_group_name = try(trimspace(var.resource_group_name), "") != "" ? var.resource_group_name : "rg-${var.project_name}-${var.env_name}"
+  app_service_plan_name = try(trimspace(var.app_service_plan_name), "") != "" ? var.app_service_plan_name : "asp-${var.project_name}-web-${var.env_name}-${var.location}"
+  app_service_name =
+    try(trimspace(var.app_service_name), "") != "" ? var.app_service_name :
+    try(trimspace(var.app_service_fqdn_prefix), "") != "" ? var.app_service_fqdn_prefix :
+    "app-${var.project_name}-web-${var.env_name}"
 }
 
 resource "azurerm_service_plan" "plan" {
-  name                = var.plan_name
+  name                = local.app_service_plan_name
   location            = var.location
-  resource_group_name = var.resource_group_name
+  resource_group_name = local.resource_group_name
   os_type             = "Linux"
-  sku_name            = var.plan_sku
+  sku_name            = var.app_service_plan_sku
   tags                = var.tags
 }
 
 resource "azurerm_linux_web_app" "app" {
-  name                = var.name
+  name                = local.app_service_name
   location            = var.location
-  resource_group_name = var.resource_group_name
+  resource_group_name = local.resource_group_name
   service_plan_id     = azurerm_service_plan.plan.id
   https_only          = true
 
@@ -23,27 +28,25 @@ resource "azurerm_linux_web_app" "app" {
   }
 
   site_config {
-    always_on = var.always_on
+    always_on  = true
     ftps_state = "Disabled"
 
     application_stack {
-      dotnet_version = local.normalized_runtime_stack == "dotnet" ? var.runtime_version : null
-      node_version   = local.normalized_runtime_stack == "node"   ? var.runtime_version : null
-      python_version = local.normalized_runtime_stack == "python" ? var.runtime_version : null
+      dotnet_version = var.app_service_dotnet_version
     }
   }
 
   app_settings = merge(
     {
-      "APPINSIGHTS_CONNECTION_STRING" = var.app_insights_connection_string
-      "APPINSIGHTS_CONNECTIONSTRING"  = var.app_insights_connection_string
+      "APPINSIGHTS_CONNECTION_STRING" = var.app_service_app_insights_connection_string
+      "APPINSIGHTS_CONNECTIONSTRING"  = var.app_service_app_insights_connection_string
     },
-    var.run_from_package == true ? { "WEBSITE_RUN_FROM_PACKAGE" = "1" } : {},
-    var.app_settings
+    var.app_service_run_from_package ? { "WEBSITE_RUN_FROM_PACKAGE" = "1" } : {},
+    var.app_service_app_settings
   )
 
   dynamic "connection_string" {
-    for_each = var.connection_strings
+    for_each = var.app_service_connection_strings
     content {
       name  = connection_string.key
       type  = connection_string.value.type
@@ -55,11 +58,11 @@ resource "azurerm_linux_web_app" "app" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "app" {
-  count = var.log_analytics_workspace_id == null || var.log_analytics_workspace_id == "" ? 0 : 1
+  count = try(trimspace(var.app_service_log_analytics_workspace_id), "") != "" ? 1 : 0
 
-  name                       = "${var.name}-diag"
+  name                       = "${local.app_service_name}-diag"
   target_resource_id         = azurerm_linux_web_app.app.id
-  log_analytics_workspace_id = var.log_analytics_workspace_id
+  log_analytics_workspace_id = var.app_service_log_analytics_workspace_id
 
   dynamic "log" {
     for_each = [

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -125,6 +125,30 @@ variable "dns_cname_records" {
 # App Services
 # -------------------------
 
+variable "resource_group_name" {
+  description = "Name of the resource group hosting the App Service resources. Defaults to rg-<project>-<env> when omitted."
+  type        = string
+  default     = null
+}
+
+variable "app_service_plan_name" {
+  description = "Explicit name assigned to the App Service plan. Defaults to asp-<project>-web-<env>-<location> when unset."
+  type        = string
+  default     = null
+}
+
+variable "app_service_name" {
+  description = "Name assigned to the primary App Service. Falls back to app_service_fqdn_prefix or app-<project>-web-<env>."
+  type        = string
+  default     = null
+}
+
+variable "app_service_fqdn_prefix" {
+  description = "Prefix used when composing the default hostname for the primary web app."
+  type        = string
+  default     = null
+}
+
 variable "app_service_plan_sku" {
   description = "SKU for the App Service plan hosting the primary web application."
   type        = string
@@ -145,6 +169,12 @@ variable "app_service_app_insights_connection_string" {
     condition     = try(trimspace(var.app_service_app_insights_connection_string), "") != ""
     error_message = "app_service_app_insights_connection_string must be provided when deploying the web app."
   }
+}
+
+variable "app_service_run_from_package" {
+  description = "When true, sets WEBSITE_RUN_FROM_PACKAGE to 1 for the primary web app."
+  type        = bool
+  default     = true
 }
 
 variable "app_service_log_analytics_workspace_id" {

--- a/platform/infra/envs/stage/main.tf
+++ b/platform/infra/envs/stage/main.tf
@@ -1,20 +1,25 @@
 locals {
-  normalized_runtime_stack = lower(trimspace(coalesce(var.runtime_stack, "dotnet")))
+  resource_group_name = try(trimspace(var.resource_group_name), "") != "" ? var.resource_group_name : "rg-${var.project_name}-${var.env_name}"
+  app_service_plan_name = try(trimspace(var.app_service_plan_name), "") != "" ? var.app_service_plan_name : "asp-${var.project_name}-web-${var.env_name}-${var.location}"
+  app_service_name =
+    try(trimspace(var.app_service_name), "") != "" ? var.app_service_name :
+    try(trimspace(var.app_service_fqdn_prefix), "") != "" ? var.app_service_fqdn_prefix :
+    "app-${var.project_name}-web-${var.env_name}"
 }
 
 resource "azurerm_service_plan" "plan" {
-  name                = var.plan_name
+  name                = local.app_service_plan_name
   location            = var.location
-  resource_group_name = var.resource_group_name
+  resource_group_name = local.resource_group_name
   os_type             = "Linux"
-  sku_name            = var.plan_sku
+  sku_name            = var.app_service_plan_sku
   tags                = var.tags
 }
 
 resource "azurerm_linux_web_app" "app" {
-  name                = var.name
+  name                = local.app_service_name
   location            = var.location
-  resource_group_name = var.resource_group_name
+  resource_group_name = local.resource_group_name
   service_plan_id     = azurerm_service_plan.plan.id
   https_only          = true
 
@@ -23,27 +28,25 @@ resource "azurerm_linux_web_app" "app" {
   }
 
   site_config {
-    always_on = var.always_on
+    always_on  = true
     ftps_state = "Disabled"
 
     application_stack {
-      dotnet_version = local.normalized_runtime_stack == "dotnet" ? var.runtime_version : null
-      node_version   = local.normalized_runtime_stack == "node"   ? var.runtime_version : null
-      python_version = local.normalized_runtime_stack == "python" ? var.runtime_version : null
+      dotnet_version = var.app_service_dotnet_version
     }
   }
 
   app_settings = merge(
     {
-      "APPINSIGHTS_CONNECTION_STRING" = var.app_insights_connection_string
-      "APPINSIGHTS_CONNECTIONSTRING"  = var.app_insights_connection_string
+      "APPINSIGHTS_CONNECTION_STRING" = var.app_service_app_insights_connection_string
+      "APPINSIGHTS_CONNECTIONSTRING"  = var.app_service_app_insights_connection_string
     },
-    var.run_from_package == true ? { "WEBSITE_RUN_FROM_PACKAGE" = "1" } : {},
-    var.app_settings
+    var.app_service_run_from_package ? { "WEBSITE_RUN_FROM_PACKAGE" = "1" } : {},
+    var.app_service_app_settings
   )
 
   dynamic "connection_string" {
-    for_each = var.connection_strings
+    for_each = var.app_service_connection_strings
     content {
       name  = connection_string.key
       type  = connection_string.value.type
@@ -55,11 +58,11 @@ resource "azurerm_linux_web_app" "app" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "app" {
-  count = var.log_analytics_workspace_id == null || var.log_analytics_workspace_id == "" ? 0 : 1
+  count = try(trimspace(var.app_service_log_analytics_workspace_id), "") != "" ? 1 : 0
 
-  name                       = "${var.name}-diag"
+  name                       = "${local.app_service_name}-diag"
   target_resource_id         = azurerm_linux_web_app.app.id
-  log_analytics_workspace_id = var.log_analytics_workspace_id
+  log_analytics_workspace_id = var.app_service_log_analytics_workspace_id
 
   dynamic "log" {
     for_each = [

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -125,6 +125,30 @@ variable "dns_cname_records" {
 # App Services
 # -------------------------
 
+variable "resource_group_name" {
+  description = "Name of the resource group hosting the App Service resources. Defaults to rg-<project>-<env> when omitted."
+  type        = string
+  default     = null
+}
+
+variable "app_service_plan_name" {
+  description = "Explicit name assigned to the App Service plan. Defaults to asp-<project>-web-<env>-<location> when unset."
+  type        = string
+  default     = null
+}
+
+variable "app_service_name" {
+  description = "Name assigned to the primary App Service. Falls back to app_service_fqdn_prefix or app-<project>-web-<env>."
+  type        = string
+  default     = null
+}
+
+variable "app_service_fqdn_prefix" {
+  description = "Prefix used when composing the default hostname for the primary web app."
+  type        = string
+  default     = null
+}
+
 variable "app_service_plan_sku" {
   description = "SKU for the App Service plan hosting the primary web application."
   type        = string
@@ -145,6 +169,12 @@ variable "app_service_app_insights_connection_string" {
     condition     = try(trimspace(var.app_service_app_insights_connection_string), "") != ""
     error_message = "app_service_app_insights_connection_string must be provided when deploying the web app."
   }
+}
+
+variable "app_service_run_from_package" {
+  description = "When true, sets WEBSITE_RUN_FROM_PACKAGE to 1 for the primary web app."
+  type        = bool
+  default     = true
 }
 
 variable "app_service_log_analytics_workspace_id" {


### PR DESCRIPTION
## Summary
- derive the App Service plan, web app, and resource group names from optional overrides so the dev, stage, and prod environments use the `app_service_*` inputs
- add supporting variables for the names, FQDN prefix, and run-from-package flag to eliminate undeclared-variable errors across the three environments

## Testing
- terraform -chdir=platform/infra/envs/dev validate *(fails: terraform command not available in the container)*
- terraform -chdir=platform/infra/envs/stage validate *(fails: terraform command not available in the container)*
- terraform -chdir=platform/infra/envs/prod validate *(fails: terraform command not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a9accba08326a934ff74d81a5ca9