### PR TITLE
Enable system-assigned identity for arbitration app service

### DIFF
--- a/platform/infra/Azure/modules/app-service-arbitration/main.tf
+++ b/platform/infra/Azure/modules/app-service-arbitration/main.tf
@@ -32,6 +32,10 @@ resource "azurerm_windows_web_app" "this" {
     }
   }
 
+  identity {
+    type = "SystemAssigned"
+  }
+
   tags = var.tags
 }
 


### PR DESCRIPTION
## Summary
- enable a system-assigned managed identity for the arbitration App Service module so the principal ID output is always populated

## Testing
- terraform init -backend=false *(fails: terraform command not available in container)*


------
https://chatgpt.com/codex/tasks/task_e_68caf9e30078832681b8d1322ff1d621