### PR TITLE
Inject App Insights settings into arbitration app module

### DIFF
--- a/platform/infra/Azure/modules/app-service-arbitration/main.tf
+++ b/platform/infra/Azure/modules/app-service-arbitration/main.tf
@@ -20,8 +20,16 @@ resource "azurerm_windows_web_app" "this" {
     always_on = true
   }
 
-  https_only   = true
-  app_settings = var.app_settings
+  https_only = true
+  app_settings = merge(
+    var.app_settings,
+    {
+      APPLICATIONINSIGHTS_CONNECTION_STRING = var.app_insights_connection_string
+    },
+    var.app_insights_instrumentation_key != null && var.app_insights_instrumentation_key != "" ? {
+      APPINSIGHTS_INSTRUMENTATIONKEY = var.app_insights_instrumentation_key
+    } : {}
+  )
 
   dynamic "connection_string" {
     for_each = var.connection_strings

--- a/platform/infra/Azure/modules/app-service-arbitration/variables.tf
+++ b/platform/infra/Azure/modules/app-service-arbitration/variables.tf
@@ -63,3 +63,9 @@ variable "app_insights_connection_string" {
   type        = string
   description = "Application Insights connection string to link App Service with monitoring"
 }
+
+variable "app_insights_instrumentation_key" {
+  type        = string
+  description = "Optional Application Insights instrumentation key for legacy integrations"
+  default     = null
+}

--- a/platform/infra/envs/dev/main.tf
+++ b/platform/infra/envs/dev/main.tf
@@ -86,6 +86,7 @@ module "app_service_arbitration" {
   runtime_stack                  = local.arbitration_runtime_stack_effective
   runtime_version                = local.arbitration_runtime_version_effective
   app_insights_connection_string = module.app_insights.application_insights_connection_string
+  app_insights_instrumentation_key = module.app_insights.application_insights_instrumentation_key
   log_analytics_workspace_id     = module.app_insights.log_analytics_workspace_id
   connection_strings             = var.arbitration_connection_strings
   app_settings                   = var.arbitration_app_settings


### PR DESCRIPTION
## Summary
- merge the arbitration app service module's caller app settings with Application Insights monitoring keys
- allow optionally supplying an instrumentation key alongside the required connection string
- pass the instrumentation key from the dev environment module so both monitoring settings flow through

## Testing
- ⚠️ `terraform plan` *(blocked: terraform binary is unavailable in the execution environment due to network restrictions preventing download)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0af4cbb883269bf616ccb3981562