### PR TITLE
Align QA arbitration runtime with .NET 6

### DIFF
--- a/platform/infra/envs/qa/main.tf
+++ b/platform/infra/envs/qa/main.tf
@@ -16,7 +16,7 @@ locals {
   arbitration_app_name                  = "web-${var.project_name}-${var.env_name}-arb"
   arbitration_plan_sku_effective        = var.arbitration_plan_sku != "" ? trimspace(var.arbitration_plan_sku) : "B1"
   arbitration_runtime_stack_effective   = var.arbitration_runtime_stack != "" ? trimspace(var.arbitration_runtime_stack) : "dotnet"
-  arbitration_runtime_version_effective = var.arbitration_runtime_version != "" ? trimspace(var.arbitration_runtime_version) : "8.0"
+  arbitration_runtime_version_effective = var.arbitration_runtime_version != "" ? trimspace(var.arbitration_runtime_version) : "v6.0"
   storage_data_name                     = lower(replace("st${var.project_name}${var.env_name}data", "-", ""))
   sql_server_name                       = "sql-${var.project_name}-${var.env_name}"
   aad_app_display                       = "aad-${var.project_name}-${var.env_name}"

--- a/platform/infra/envs/qa/terraform.tfvars
+++ b/platform/infra/envs/qa/terraform.tfvars
@@ -82,7 +82,7 @@ kv_public_network_access = true
 # -------------------------
 arbitration_plan_sku        = "S1"
 arbitration_runtime_stack   = "dotnet"
-arbitration_runtime_version = "8.0"
+arbitration_runtime_version = "v6.0"
 
 arbitration_connection_strings = [
   {


### PR DESCRIPTION
## Summary
- set the QA arbitration runtime version to the Azure-supported v6.0 value
- align the QA environment's default arbitration runtime fallback with the shared .NET 6 stack

## Testing
- terraform init -backend=false *(fails: terraform not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1ee25c288326b173b2a56c225500