### PR TITLE
Add stage environment core modules and SQL secret lookup

### DIFF
--- a/platform/infra/envs/stage/main.tf
+++ b/platform/infra/envs/stage/main.tf
@@ -59,3 +59,222 @@ locals {
     })
   }
 }
+
+# -------------------------
+# Core modules
+# -------------------------
+module "resource_group" {
+  source   = "../../Azure/modules/resource-group"
+  name     = local.rg_name
+  location = var.location
+  tags     = var.tags
+}
+
+module "network" {
+  source              = "../../Azure/modules/network"
+  name                = "vnet-${var.project_name}-${var.env_name}"
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  address_space       = var.vnet_address_space
+  dns_servers         = var.vnet_dns_servers
+  subnets             = var.subnets
+  tags                = var.tags
+}
+
+module "arbitration_storage_account" {
+  source              = "../../Azure/modules/storage-account"
+  name                = local.storage_data_name
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  tags                = var.tags
+}
+
+module "arbitration_storage_container" {
+  source               = "../../Azure/modules/storage-container"
+  name                 = var.arbitration_storage_container_name
+  storage_account_name = module.arbitration_storage_account.name
+}
+
+module "app_service" {
+  source              = "../../Azure/modules/app-service"
+  plan_name           = local.web_plan
+  plan_sku            = var.app_service_plan_sku
+  plan_os_type        = var.app_service_plan_os_type
+  app_name            = var.app_service_fqdn_prefix
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  https_only          = var.app_service_https_only
+  always_on           = var.app_service_always_on
+  app_settings        = var.app_service_app_settings
+  connection_strings  = var.app_service_connection_strings
+  tags                = var.tags
+}
+
+module "app_insights" {
+  source                       = "../../Azure/modules/app-insights"
+  resource_group_name          = module.resource_group.name
+  location                     = var.location
+  log_analytics_workspace_name = local.log_name
+  application_insights_name    = local.appi_name
+  tags                         = var.tags
+}
+
+module "app_service_arbitration" {
+  source                         = "../../Azure/modules/app-service-arbitration"
+  name                           = local.arbitration_name
+  plan_name                      = local.arbitration_plan
+  plan_sku                       = local.arbitration_plan_sku_effective
+  resource_group_name            = module.resource_group.name
+  location                       = var.location
+  runtime_stack                  = local.arbitration_runtime_stack_effective
+  runtime_version                = local.arbitration_runtime_version_effective
+  app_insights_connection_string = module.app_insights.application_insights_connection_string
+  app_insights_instrumentation_key = module.app_insights.application_insights_instrumentation_key
+  log_analytics_workspace_id     = module.app_insights.log_analytics_workspace_id
+  connection_strings             = var.arbitration_connection_strings
+  app_settings                   = var.arbitration_app_settings
+  tags                           = var.tags
+}
+
+module "app_gateway" {
+  source                              = "../../Azure/modules/app-gateway"
+  name                                = local.app_gateway_name
+  resource_group_name                 = module.resource_group.name
+  location                            = var.location
+  subnet_id                           = module.network.subnet_ids[var.app_gateway_subnet_key]
+  fqdn_prefix                         = var.app_gateway_fqdn_prefix
+  backend_fqdns                       = local.app_gateway_backend_fqdns
+  backend_port                        = var.app_gateway_backend_port
+  frontend_port                       = var.app_gateway_frontend_port
+  listener_protocol                   = var.app_gateway_listener_protocol
+  sku_name                            = var.app_gateway_sku_name
+  sku_tier                            = var.app_gateway_sku_tier
+  sku_capacity                        = var.app_gateway_capacity
+  enable_http2                        = var.app_gateway_enable_http2
+  pick_host_name_from_backend_address = var.app_gateway_pick_host_name
+  tags                                = var.tags
+}
+
+module "sql" {
+  count                         = var.enable_sql && local.sql_admin_login_effective != "" && local.resolved_sql_admin_password != "" ? 1 : 0
+  source                        = "../../Azure/modules/sql-serverless"
+  server_name                   = local.sql_server_name
+  database_name                 = local.sql_database_name
+  resource_group_name           = module.resource_group.name
+  location                      = var.location
+  administrator_login           = local.sql_admin_login_effective
+  administrator_password        = local.resolved_sql_admin_password
+  public_network_access_enabled = var.sql_public_network_access
+  minimum_tls_version           = var.sql_minimum_tls_version
+  sku_name                      = var.sql_sku_name
+  auto_pause_delay_in_minutes   = var.sql_auto_pause_delay
+  max_size_gb                   = var.sql_max_size_gb
+  min_capacity                  = var.sql_min_capacity
+  max_capacity                  = var.sql_max_capacity
+  read_scale                    = var.sql_read_scale
+  zone_redundant                = var.sql_zone_redundant
+  collation                     = var.sql_collation
+  firewall_rules                = var.sql_firewall_rules
+  tags                          = var.tags
+}
+
+module "kv" {
+  source                        = "../../Azure/modules/key-vault"
+  name                          = local.kv_name
+  resource_group_name           = module.resource_group.name
+  location                      = var.location
+  public_network_access_enabled = var.kv_public_network_access
+  tags                          = var.tags
+  secrets = {
+    "arbitration-storage-connection" = module.arbitration_storage_account.primary_connection_string
+  }
+}
+
+module "dns_zone" {
+  source              = "../../Azure/modules/dns-zone"
+  zone_name           = var.dns_zone_name
+  resource_group_name = module.resource_group.name
+  tags                = var.tags
+  a_records           = var.dns_a_records
+  cname_records       = local.dns_cname_records
+}
+
+# -------------------------
+# Data sources
+# -------------------------
+data "azurerm_key_vault_secret" "sql_admin_password" {
+  count = try(trim(var.sql_admin_password_secret_name), "") != "" ? 1 : 0
+
+  name         = var.sql_admin_password_secret_name
+  key_vault_id = module.kv.id
+
+  depends_on = [module.kv]
+}
+
+# -------------------------
+# Outputs
+# -------------------------
+output "resource_group_name" {
+  description = "Resource group provisioned for the environment."
+  value       = module.resource_group.name
+}
+
+output "virtual_network_id" {
+  description = "ID of the deployed virtual network."
+  value       = module.network.virtual_network_id
+}
+
+output "app_service_default_hostname" {
+  description = "Default hostname assigned to the primary App Service."
+  value       = module.app_service.default_hostname
+}
+
+output "arbitration_app_service_default_hostname" {
+  description = "Default hostname assigned to the arbitration App Service."
+  value       = module.app_service_arbitration.default_hostname
+}
+
+output "app_gateway_id" {
+  description = "ID of the Application Gateway."
+  value       = module.app_gateway.id
+}
+
+output "app_gateway_public_ip_address" {
+  description = "Allocated public IP address of the Application Gateway."
+  value       = module.app_gateway.public_ip_address
+}
+
+output "app_gateway_public_fqdn" {
+  description = "Public FQDN assigned to the Application Gateway."
+  value       = module.app_gateway.public_ip_fqdn
+}
+
+output "sql_server_fqdn" {
+  description = "Fully qualified domain name of the SQL Server."
+  value       = length(module.sql) > 0 ? module.sql[0].server_fqdn : null
+}
+
+output "sql_database_id" {
+  description = "Database resource ID."
+  value       = length(module.sql) > 0 ? module.sql[0].database_id : null
+}
+
+output "sql_server_name" {
+  description = "SQL Server name."
+  value       = length(module.sql) > 0 ? module.sql[0].server_name : null
+}
+
+output "app_insights_connection_string" {
+  description = "Application Insights connection string."
+  value       = module.app_insights.application_insights_connection_string
+}
+
+output "app_insights_instrumentation_key" {
+  description = "Application Insights instrumentation key."
+  value       = module.app_insights.application_insights_instrumentation_key
+}
+
+output "log_analytics_workspace_id" {
+  description = "Log Analytics workspace ID."
+  value       = module.app_insights.log_analytics_workspace_id
+}


### PR DESCRIPTION
## Summary
- add the missing core infrastructure modules for the stage environment so downstream references resolve
- hook the stage App Service, Application Insights, Application Gateway, SQL, and Key Vault resources together similar to the other environments
- add an optional Key Vault secret lookup that feeds the SQL administrator password fallback logic

## Testing
- terraform validate *(not run: terraform binary could not be installed because outbound downloads are blocked by the proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1edf05c883268145c4da84130508