### PR TITLE
Remove unused workflow networking variables

### DIFF
--- a/platform/infra/envs/dev/main.tf
+++ b/platform/infra/envs/dev/main.tf
@@ -24,32 +24,13 @@ module "arbit_workflow" {
   function_dns_zone_name           = var.function_dns_zone_name
   function_dns_resource_group_name = var.function_dns_resource_group_name
 
-  azure_vpn_ipv4         = var.azure_vpn_ipv4
-  sonicwall_vpn_ipv4     = var.sonicwall_vpn_ipv4
-  point_to_site_vpn_ipv4 = var.point_to_site_vpn_ipv4
   vpns_ipv4              = var.vpns_ipv4
-  vdis_ipv4              = var.vdis_ipv4
   mpower_brief_avd_pool_ipv4    = var.mpower_brief_avd_pool_ipv4
   briefbuilder_development_vdis = var.briefbuilder_development_vdis
-  halomd_development_test_vdi   = var.halomd_development_test_vdi
-  halomd_brief_avd_vnet_ipv4    = var.halomd_brief_avd_vnet_ipv4
   monitoring_ipv4        = var.monitoring_ipv4
   octopus_ipv4           = var.octopus_ipv4
-  builder_ipv4           = var.builder_ipv4
-  dagster_ipv4           = var.dagster_ipv4
 
-  public_operations_subnet      = var.public_operations_subnet
-  public_gateways_subnet        = var.public_gateways_subnet
-  private_asps_subnet           = var.private_asps_subnet
-  private_gateways_subnet       = var.private_gateways_subnet
   private_applications_subnet   = var.private_applications_subnet
-  private_services_subnet       = var.private_services_subnet
-  private_powerplatform_subnet  = var.private_powerplatform_subnet
-  private_psql_databases_subnet = var.private_psql_databases_subnet
-  private_dataplatform_subnet   = var.private_dataplatform_subnet
-  private_operations_subnet     = var.private_operations_subnet
-  public_mssql_databases_subnet = var.public_mssql_databases_subnet
-  private_databases_subnet      = var.private_databases_subnet
 
   workflow_storage_account_docs              = var.workflow_storage_account_docs
   workflow_storage_account_cron_function     = var.workflow_storage_account_cron_function

--- a/platform/infra/envs/dev/terraform.tfvars
+++ b/platform/infra/envs/dev/terraform.tfvars
@@ -18,9 +18,6 @@ main_vnet           = "dev-eus2-ops-vnet-1"
 function_dns_zone_name           = "privatelink.azurewebsites.net"
 function_dns_resource_group_name = "hub-eus2-vnet-rg-1"
 
-azure_vpn_ipv4         = "10.0.0.0/24"
-sonicwall_vpn_ipv4     = "10.1.0.0/24"
-point_to_site_vpn_ipv4 = "10.2.0.0/24"
 vpns_ipv4 = [
   "10.0.0.0/24",
   "10.1.0.0/24",
@@ -42,25 +39,7 @@ ml_virtual_machine_count = 2
 
 # Optional IP allowlists
 briefbuilder_development_vdis = []
-halomd_development_test_vdi   = []
-halomd_brief_avd_vnet_ipv4    = []
 mpower_brief_avd_pool_ipv4    = []
-vdis_ipv4                     = []
-
-builder_ipv4 = ""
-dagster_ipv4 = ""
-
-public_operations_subnet      = ""
-public_gateways_subnet        = ""
-private_asps_subnet           = ""
-private_gateways_subnet       = ""
-private_services_subnet       = ""
-private_powerplatform_subnet  = ""
-private_psql_databases_subnet = ""
-private_dataplatform_subnet   = ""
-private_operations_subnet     = ""
-public_mssql_databases_subnet = ""
-private_databases_subnet      = ""
 
 # Secrets are injected at runtime via the pipeline / Key Vault where applicable.
 

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -79,32 +79,8 @@ variable "function_dns_resource_group_name" {
   type        = string
 }
 
-variable "azure_vpn_ipv4" {
-  description = "Azure VPN IPv4 CIDR block."
-  type        = string
-  default     = ""
-}
-
-variable "sonicwall_vpn_ipv4" {
-  description = "SonicWall VPN IPv4 CIDR block."
-  type        = string
-  default     = ""
-}
-
-variable "point_to_site_vpn_ipv4" {
-  description = "Point-to-site VPN IPv4 CIDR block."
-  type        = string
-  default     = ""
-}
-
 variable "vpns_ipv4" {
   description = "List of VPN IPv4 CIDR blocks allowed through network security rules."
-  type        = list(string)
-  default     = []
-}
-
-variable "vdis_ipv4" {
-  description = "List of VDI IPv4 CIDR blocks."
   type        = list(string)
   default     = []
 }
@@ -121,18 +97,6 @@ variable "briefbuilder_development_vdis" {
   default     = []
 }
 
-variable "halomd_development_test_vdi" {
-  description = "HaloMD development/test VDI IPv4 ranges."
-  type        = list(string)
-  default     = []
-}
-
-variable "halomd_brief_avd_vnet_ipv4" {
-  description = "HaloMD brief AVD virtual network IPv4 ranges."
-  type        = list(string)
-  default     = []
-}
-
 variable "monitoring_ipv4" {
   description = "Prometheus monitoring IPv4 CIDR block."
   type        = string
@@ -143,87 +107,9 @@ variable "octopus_ipv4" {
   type        = string
 }
 
-variable "builder_ipv4" {
-  description = "Builder IPv4 address."
-  type        = string
-  default     = ""
-}
-
-variable "dagster_ipv4" {
-  description = "Dagster IPv4 address."
-  type        = string
-  default     = ""
-}
-
-variable "public_operations_subnet" {
-  description = "Public operations subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "public_gateways_subnet" {
-  description = "Public gateways subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_asps_subnet" {
-  description = "Private ASPs subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_gateways_subnet" {
-  description = "Private gateways subnet prefix."
-  type        = string
-  default     = ""
-}
-
 variable "private_applications_subnet" {
   description = "Private applications subnet prefix used for ML VMs."
   type        = string
-}
-
-variable "private_services_subnet" {
-  description = "Private services subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_powerplatform_subnet" {
-  description = "Private Power Platform subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_psql_databases_subnet" {
-  description = "Private PostgreSQL databases subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_dataplatform_subnet" {
-  description = "Private data platform subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_operations_subnet" {
-  description = "Private operations subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "public_mssql_databases_subnet" {
-  description = "Public MSSQL subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_databases_subnet" {
-  description = "Private databases subnet prefix."
-  type        = string
-  default     = ""
 }
 
 variable "workflow_storage_account_docs" {

--- a/platform/infra/envs/prod/main.tf
+++ b/platform/infra/envs/prod/main.tf
@@ -24,32 +24,13 @@ module "arbit_workflow" {
   function_dns_zone_name           = var.function_dns_zone_name
   function_dns_resource_group_name = var.function_dns_resource_group_name
 
-  azure_vpn_ipv4         = var.azure_vpn_ipv4
-  sonicwall_vpn_ipv4     = var.sonicwall_vpn_ipv4
-  point_to_site_vpn_ipv4 = var.point_to_site_vpn_ipv4
   vpns_ipv4              = var.vpns_ipv4
-  vdis_ipv4              = var.vdis_ipv4
   mpower_brief_avd_pool_ipv4    = var.mpower_brief_avd_pool_ipv4
   briefbuilder_development_vdis = var.briefbuilder_development_vdis
-  halomd_development_test_vdi   = var.halomd_development_test_vdi
-  halomd_brief_avd_vnet_ipv4    = var.halomd_brief_avd_vnet_ipv4
   monitoring_ipv4        = var.monitoring_ipv4
   octopus_ipv4           = var.octopus_ipv4
-  builder_ipv4           = var.builder_ipv4
-  dagster_ipv4           = var.dagster_ipv4
 
-  public_operations_subnet      = var.public_operations_subnet
-  public_gateways_subnet        = var.public_gateways_subnet
-  private_asps_subnet           = var.private_asps_subnet
-  private_gateways_subnet       = var.private_gateways_subnet
   private_applications_subnet   = var.private_applications_subnet
-  private_services_subnet       = var.private_services_subnet
-  private_powerplatform_subnet  = var.private_powerplatform_subnet
-  private_psql_databases_subnet = var.private_psql_databases_subnet
-  private_dataplatform_subnet   = var.private_dataplatform_subnet
-  private_operations_subnet     = var.private_operations_subnet
-  public_mssql_databases_subnet = var.public_mssql_databases_subnet
-  private_databases_subnet      = var.private_databases_subnet
 
   workflow_storage_account_docs              = var.workflow_storage_account_docs
   workflow_storage_account_cron_function     = var.workflow_storage_account_cron_function

--- a/platform/infra/envs/prod/terraform.tfvars
+++ b/platform/infra/envs/prod/terraform.tfvars
@@ -18,9 +18,6 @@ main_vnet           = "prod-eus2-ops-vnet-1"
 function_dns_zone_name           = "privatelink.azurewebsites.net"
 function_dns_resource_group_name = "hub-eus2-vnet-rg-1"
 
-azure_vpn_ipv4         = "10.0.0.0/24"
-sonicwall_vpn_ipv4     = "10.1.0.0/24"
-point_to_site_vpn_ipv4 = "10.2.0.0/24"
 vpns_ipv4 = [
   "10.0.0.0/24",
   "10.1.0.0/24",
@@ -41,25 +38,7 @@ workflow_sqlserver_dbadmin_password = null
 ml_virtual_machine_count = 2
 
 briefbuilder_development_vdis = []
-halomd_development_test_vdi   = []
-halomd_brief_avd_vnet_ipv4    = []
 mpower_brief_avd_pool_ipv4    = []
-vdis_ipv4                     = []
-
-builder_ipv4 = ""
-dagster_ipv4 = ""
-
-public_operations_subnet      = ""
-public_gateways_subnet        = ""
-private_asps_subnet           = ""
-private_gateways_subnet       = ""
-private_services_subnet       = ""
-private_powerplatform_subnet  = ""
-private_psql_databases_subnet = ""
-private_dataplatform_subnet   = ""
-private_operations_subnet     = ""
-public_mssql_databases_subnet = ""
-private_databases_subnet      = ""
 
 tags = {
   project = "arbit"

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -79,32 +79,8 @@ variable "function_dns_resource_group_name" {
   type        = string
 }
 
-variable "azure_vpn_ipv4" {
-  description = "Azure VPN IPv4 CIDR block."
-  type        = string
-  default     = ""
-}
-
-variable "sonicwall_vpn_ipv4" {
-  description = "SonicWall VPN IPv4 CIDR block."
-  type        = string
-  default     = ""
-}
-
-variable "point_to_site_vpn_ipv4" {
-  description = "Point-to-site VPN IPv4 CIDR block."
-  type        = string
-  default     = ""
-}
-
 variable "vpns_ipv4" {
   description = "List of VPN IPv4 CIDR blocks allowed through network security rules."
-  type        = list(string)
-  default     = []
-}
-
-variable "vdis_ipv4" {
-  description = "List of VDI IPv4 CIDR blocks."
   type        = list(string)
   default     = []
 }
@@ -121,18 +97,6 @@ variable "briefbuilder_development_vdis" {
   default     = []
 }
 
-variable "halomd_development_test_vdi" {
-  description = "HaloMD development/test VDI IPv4 ranges."
-  type        = list(string)
-  default     = []
-}
-
-variable "halomd_brief_avd_vnet_ipv4" {
-  description = "HaloMD brief AVD virtual network IPv4 ranges."
-  type        = list(string)
-  default     = []
-}
-
 variable "monitoring_ipv4" {
   description = "Prometheus monitoring IPv4 CIDR block."
   type        = string
@@ -143,87 +107,9 @@ variable "octopus_ipv4" {
   type        = string
 }
 
-variable "builder_ipv4" {
-  description = "Builder IPv4 address."
-  type        = string
-  default     = ""
-}
-
-variable "dagster_ipv4" {
-  description = "Dagster IPv4 address."
-  type        = string
-  default     = ""
-}
-
-variable "public_operations_subnet" {
-  description = "Public operations subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "public_gateways_subnet" {
-  description = "Public gateways subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_asps_subnet" {
-  description = "Private ASPs subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_gateways_subnet" {
-  description = "Private gateways subnet prefix."
-  type        = string
-  default     = ""
-}
-
 variable "private_applications_subnet" {
   description = "Private applications subnet prefix used for ML VMs."
   type        = string
-}
-
-variable "private_services_subnet" {
-  description = "Private services subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_powerplatform_subnet" {
-  description = "Private Power Platform subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_psql_databases_subnet" {
-  description = "Private PostgreSQL databases subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_dataplatform_subnet" {
-  description = "Private data platform subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_operations_subnet" {
-  description = "Private operations subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "public_mssql_databases_subnet" {
-  description = "Public MSSQL subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_databases_subnet" {
-  description = "Private databases subnet prefix."
-  type        = string
-  default     = ""
 }
 
 variable "workflow_storage_account_docs" {

--- a/platform/infra/envs/qa/main.tf
+++ b/platform/infra/envs/qa/main.tf
@@ -24,32 +24,13 @@ module "arbit_workflow" {
   function_dns_zone_name           = var.function_dns_zone_name
   function_dns_resource_group_name = var.function_dns_resource_group_name
 
-  azure_vpn_ipv4         = var.azure_vpn_ipv4
-  sonicwall_vpn_ipv4     = var.sonicwall_vpn_ipv4
-  point_to_site_vpn_ipv4 = var.point_to_site_vpn_ipv4
   vpns_ipv4              = var.vpns_ipv4
-  vdis_ipv4              = var.vdis_ipv4
   mpower_brief_avd_pool_ipv4    = var.mpower_brief_avd_pool_ipv4
   briefbuilder_development_vdis = var.briefbuilder_development_vdis
-  halomd_development_test_vdi   = var.halomd_development_test_vdi
-  halomd_brief_avd_vnet_ipv4    = var.halomd_brief_avd_vnet_ipv4
   monitoring_ipv4        = var.monitoring_ipv4
   octopus_ipv4           = var.octopus_ipv4
-  builder_ipv4           = var.builder_ipv4
-  dagster_ipv4           = var.dagster_ipv4
 
-  public_operations_subnet      = var.public_operations_subnet
-  public_gateways_subnet        = var.public_gateways_subnet
-  private_asps_subnet           = var.private_asps_subnet
-  private_gateways_subnet       = var.private_gateways_subnet
   private_applications_subnet   = var.private_applications_subnet
-  private_services_subnet       = var.private_services_subnet
-  private_powerplatform_subnet  = var.private_powerplatform_subnet
-  private_psql_databases_subnet = var.private_psql_databases_subnet
-  private_dataplatform_subnet   = var.private_dataplatform_subnet
-  private_operations_subnet     = var.private_operations_subnet
-  public_mssql_databases_subnet = var.public_mssql_databases_subnet
-  private_databases_subnet      = var.private_databases_subnet
 
   workflow_storage_account_docs              = var.workflow_storage_account_docs
   workflow_storage_account_cron_function     = var.workflow_storage_account_cron_function

--- a/platform/infra/envs/qa/terraform.tfvars
+++ b/platform/infra/envs/qa/terraform.tfvars
@@ -18,9 +18,6 @@ main_vnet           = "qa-eus2-ops-vnet-1"
 function_dns_zone_name           = "privatelink.azurewebsites.net"
 function_dns_resource_group_name = "hub-eus2-vnet-rg-1"
 
-azure_vpn_ipv4         = "10.0.0.0/24"
-sonicwall_vpn_ipv4     = "10.1.0.0/24"
-point_to_site_vpn_ipv4 = "10.2.0.0/24"
 vpns_ipv4 = [
   "10.0.0.0/24",
   "10.1.0.0/24",
@@ -41,25 +38,7 @@ workflow_sqlserver_dbadmin_password = null
 ml_virtual_machine_count = 2
 
 briefbuilder_development_vdis = []
-halomd_development_test_vdi   = []
-halomd_brief_avd_vnet_ipv4    = []
 mpower_brief_avd_pool_ipv4    = []
-vdis_ipv4                     = []
-
-builder_ipv4 = ""
-dagster_ipv4 = ""
-
-public_operations_subnet      = ""
-public_gateways_subnet        = ""
-private_asps_subnet           = ""
-private_gateways_subnet       = ""
-private_services_subnet       = ""
-private_powerplatform_subnet  = ""
-private_psql_databases_subnet = ""
-private_dataplatform_subnet   = ""
-private_operations_subnet     = ""
-public_mssql_databases_subnet = ""
-private_databases_subnet      = ""
 
 tags = {
   project = "arbit"

--- a/platform/infra/envs/qa/variables.tf
+++ b/platform/infra/envs/qa/variables.tf
@@ -79,32 +79,8 @@ variable "function_dns_resource_group_name" {
   type        = string
 }
 
-variable "azure_vpn_ipv4" {
-  description = "Azure VPN IPv4 CIDR block."
-  type        = string
-  default     = ""
-}
-
-variable "sonicwall_vpn_ipv4" {
-  description = "SonicWall VPN IPv4 CIDR block."
-  type        = string
-  default     = ""
-}
-
-variable "point_to_site_vpn_ipv4" {
-  description = "Point-to-site VPN IPv4 CIDR block."
-  type        = string
-  default     = ""
-}
-
 variable "vpns_ipv4" {
   description = "List of VPN IPv4 CIDR blocks allowed through network security rules."
-  type        = list(string)
-  default     = []
-}
-
-variable "vdis_ipv4" {
-  description = "List of VDI IPv4 CIDR blocks."
   type        = list(string)
   default     = []
 }
@@ -121,18 +97,6 @@ variable "briefbuilder_development_vdis" {
   default     = []
 }
 
-variable "halomd_development_test_vdi" {
-  description = "HaloMD development/test VDI IPv4 ranges."
-  type        = list(string)
-  default     = []
-}
-
-variable "halomd_brief_avd_vnet_ipv4" {
-  description = "HaloMD brief AVD virtual network IPv4 ranges."
-  type        = list(string)
-  default     = []
-}
-
 variable "monitoring_ipv4" {
   description = "Prometheus monitoring IPv4 CIDR block."
   type        = string
@@ -143,87 +107,9 @@ variable "octopus_ipv4" {
   type        = string
 }
 
-variable "builder_ipv4" {
-  description = "Builder IPv4 address."
-  type        = string
-  default     = ""
-}
-
-variable "dagster_ipv4" {
-  description = "Dagster IPv4 address."
-  type        = string
-  default     = ""
-}
-
-variable "public_operations_subnet" {
-  description = "Public operations subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "public_gateways_subnet" {
-  description = "Public gateways subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_asps_subnet" {
-  description = "Private ASPs subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_gateways_subnet" {
-  description = "Private gateways subnet prefix."
-  type        = string
-  default     = ""
-}
-
 variable "private_applications_subnet" {
   description = "Private applications subnet prefix used for ML VMs."
   type        = string
-}
-
-variable "private_services_subnet" {
-  description = "Private services subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_powerplatform_subnet" {
-  description = "Private Power Platform subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_psql_databases_subnet" {
-  description = "Private PostgreSQL databases subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_dataplatform_subnet" {
-  description = "Private data platform subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_operations_subnet" {
-  description = "Private operations subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "public_mssql_databases_subnet" {
-  description = "Public MSSQL subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_databases_subnet" {
-  description = "Private databases subnet prefix."
-  type        = string
-  default     = ""
 }
 
 variable "workflow_storage_account_docs" {

--- a/platform/infra/envs/stage/main.tf
+++ b/platform/infra/envs/stage/main.tf
@@ -24,32 +24,13 @@ module "arbit_workflow" {
   function_dns_zone_name           = var.function_dns_zone_name
   function_dns_resource_group_name = var.function_dns_resource_group_name
 
-  azure_vpn_ipv4         = var.azure_vpn_ipv4
-  sonicwall_vpn_ipv4     = var.sonicwall_vpn_ipv4
-  point_to_site_vpn_ipv4 = var.point_to_site_vpn_ipv4
   vpns_ipv4              = var.vpns_ipv4
-  vdis_ipv4              = var.vdis_ipv4
   mpower_brief_avd_pool_ipv4    = var.mpower_brief_avd_pool_ipv4
   briefbuilder_development_vdis = var.briefbuilder_development_vdis
-  halomd_development_test_vdi   = var.halomd_development_test_vdi
-  halomd_brief_avd_vnet_ipv4    = var.halomd_brief_avd_vnet_ipv4
   monitoring_ipv4        = var.monitoring_ipv4
   octopus_ipv4           = var.octopus_ipv4
-  builder_ipv4           = var.builder_ipv4
-  dagster_ipv4           = var.dagster_ipv4
 
-  public_operations_subnet      = var.public_operations_subnet
-  public_gateways_subnet        = var.public_gateways_subnet
-  private_asps_subnet           = var.private_asps_subnet
-  private_gateways_subnet       = var.private_gateways_subnet
   private_applications_subnet   = var.private_applications_subnet
-  private_services_subnet       = var.private_services_subnet
-  private_powerplatform_subnet  = var.private_powerplatform_subnet
-  private_psql_databases_subnet = var.private_psql_databases_subnet
-  private_dataplatform_subnet   = var.private_dataplatform_subnet
-  private_operations_subnet     = var.private_operations_subnet
-  public_mssql_databases_subnet = var.public_mssql_databases_subnet
-  private_databases_subnet      = var.private_databases_subnet
 
   workflow_storage_account_docs              = var.workflow_storage_account_docs
   workflow_storage_account_cron_function     = var.workflow_storage_account_cron_function

--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -18,9 +18,6 @@ main_vnet           = "stage-eus2-ops-vnet-1"
 function_dns_zone_name           = "privatelink.azurewebsites.net"
 function_dns_resource_group_name = "hub-eus2-vnet-rg-1"
 
-azure_vpn_ipv4         = "10.0.0.0/24"
-sonicwall_vpn_ipv4     = "10.1.0.0/24"
-point_to_site_vpn_ipv4 = "10.2.0.0/24"
 vpns_ipv4 = [
   "10.0.0.0/24",
   "10.1.0.0/24",
@@ -41,25 +38,7 @@ workflow_sqlserver_dbadmin_password = null
 ml_virtual_machine_count = 2
 
 briefbuilder_development_vdis = []
-halomd_development_test_vdi   = []
-halomd_brief_avd_vnet_ipv4    = []
 mpower_brief_avd_pool_ipv4    = []
-vdis_ipv4                     = []
-
-builder_ipv4 = ""
-dagster_ipv4 = ""
-
-public_operations_subnet      = ""
-public_gateways_subnet        = ""
-private_asps_subnet           = ""
-private_gateways_subnet       = ""
-private_services_subnet       = ""
-private_powerplatform_subnet  = ""
-private_psql_databases_subnet = ""
-private_dataplatform_subnet   = ""
-private_operations_subnet     = ""
-public_mssql_databases_subnet = ""
-private_databases_subnet      = ""
 
 tags = {
   project = "arbit"

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -79,32 +79,8 @@ variable "function_dns_resource_group_name" {
   type        = string
 }
 
-variable "azure_vpn_ipv4" {
-  description = "Azure VPN IPv4 CIDR block."
-  type        = string
-  default     = ""
-}
-
-variable "sonicwall_vpn_ipv4" {
-  description = "SonicWall VPN IPv4 CIDR block."
-  type        = string
-  default     = ""
-}
-
-variable "point_to_site_vpn_ipv4" {
-  description = "Point-to-site VPN IPv4 CIDR block."
-  type        = string
-  default     = ""
-}
-
 variable "vpns_ipv4" {
   description = "List of VPN IPv4 CIDR blocks allowed through network security rules."
-  type        = list(string)
-  default     = []
-}
-
-variable "vdis_ipv4" {
-  description = "List of VDI IPv4 CIDR blocks."
   type        = list(string)
   default     = []
 }
@@ -121,18 +97,6 @@ variable "briefbuilder_development_vdis" {
   default     = []
 }
 
-variable "halomd_development_test_vdi" {
-  description = "HaloMD development/test VDI IPv4 ranges."
-  type        = list(string)
-  default     = []
-}
-
-variable "halomd_brief_avd_vnet_ipv4" {
-  description = "HaloMD brief AVD virtual network IPv4 ranges."
-  type        = list(string)
-  default     = []
-}
-
 variable "monitoring_ipv4" {
   description = "Prometheus monitoring IPv4 CIDR block."
   type        = string
@@ -143,87 +107,9 @@ variable "octopus_ipv4" {
   type        = string
 }
 
-variable "builder_ipv4" {
-  description = "Builder IPv4 address."
-  type        = string
-  default     = ""
-}
-
-variable "dagster_ipv4" {
-  description = "Dagster IPv4 address."
-  type        = string
-  default     = ""
-}
-
-variable "public_operations_subnet" {
-  description = "Public operations subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "public_gateways_subnet" {
-  description = "Public gateways subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_asps_subnet" {
-  description = "Private ASPs subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_gateways_subnet" {
-  description = "Private gateways subnet prefix."
-  type        = string
-  default     = ""
-}
-
 variable "private_applications_subnet" {
   description = "Private applications subnet prefix used for ML VMs."
   type        = string
-}
-
-variable "private_services_subnet" {
-  description = "Private services subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_powerplatform_subnet" {
-  description = "Private Power Platform subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_psql_databases_subnet" {
-  description = "Private PostgreSQL databases subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_dataplatform_subnet" {
-  description = "Private data platform subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_operations_subnet" {
-  description = "Private operations subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "public_mssql_databases_subnet" {
-  description = "Public MSSQL subnet prefix."
-  type        = string
-  default     = ""
-}
-
-variable "private_databases_subnet" {
-  description = "Private databases subnet prefix."
-  type        = string
-  default     = ""
 }
 
 variable "workflow_storage_account_docs" {

--- a/platform/infra/modules/arbit_workflow/variables.tf
+++ b/platform/infra/modules/arbit_workflow/variables.tf
@@ -44,33 +44,9 @@ variable "ipv4_prefix" {
   description = "IPv4 prefix used when deriving static addresses."
 }
 
-variable "azure_vpn_ipv4" {
-  type        = string
-  description = "Azure VPN IPv4 CIDR block."
-  default     = ""
-}
-
-variable "sonicwall_vpn_ipv4" {
-  type        = string
-  description = "SonicWall VPN IPv4 CIDR block."
-  default     = ""
-}
-
-variable "point_to_site_vpn_ipv4" {
-  type        = string
-  description = "Point-to-site VPN IPv4 CIDR block."
-  default     = ""
-}
-
 variable "vpns_ipv4" {
   type        = list(string)
   description = "List of VPN IPv4 CIDR blocks allowed through NSGs."
-}
-
-variable "vdis_ipv4" {
-  type        = list(string)
-  description = "List of VDI IPv4 CIDR blocks."
-  default     = []
 }
 
 variable "mpower_brief_avd_pool_ipv4" {
@@ -85,18 +61,6 @@ variable "briefbuilder_development_vdis" {
   default     = []
 }
 
-variable "halomd_development_test_vdi" {
-  type        = list(string)
-  description = "HaloMD development/test VDI IPv4 ranges."
-  default     = []
-}
-
-variable "halomd_brief_avd_vnet_ipv4" {
-  type        = list(string)
-  description = "HaloMD brief AVD VNet IPv4 ranges."
-  default     = []
-}
-
 variable "monitoring_ipv4" {
   type        = string
   description = "Prometheus monitoring IPv4 CIDR block."
@@ -107,87 +71,9 @@ variable "octopus_ipv4" {
   description = "Octopus deploy IPv4 address."
 }
 
-variable "builder_ipv4" {
-  type        = string
-  description = "Builder IPv4 address."
-  default     = ""
-}
-
-variable "dagster_ipv4" {
-  type        = string
-  description = "Dagster IPv4 address."
-  default     = ""
-}
-
-variable "public_operations_subnet" {
-  type        = string
-  description = "Public operations subnet prefix."
-  default     = ""
-}
-
-variable "public_gateways_subnet" {
-  type        = string
-  description = "Public gateways subnet prefix."
-  default     = ""
-}
-
-variable "private_asps_subnet" {
-  type        = string
-  description = "Private ASPs subnet prefix."
-  default     = ""
-}
-
-variable "private_gateways_subnet" {
-  type        = string
-  description = "Private gateways subnet prefix."
-  default     = ""
-}
-
 variable "private_applications_subnet" {
   type        = string
   description = "Private applications subnet prefix used for ML VMs."
-}
-
-variable "private_services_subnet" {
-  type        = string
-  description = "Private services subnet prefix."
-  default     = ""
-}
-
-variable "private_powerplatform_subnet" {
-  type        = string
-  description = "Private Power Platform subnet prefix."
-  default     = ""
-}
-
-variable "private_psql_databases_subnet" {
-  type        = string
-  description = "Private PostgreSQL databases subnet prefix."
-  default     = ""
-}
-
-variable "private_dataplatform_subnet" {
-  type        = string
-  description = "Private data platform subnet prefix."
-  default     = ""
-}
-
-variable "private_operations_subnet" {
-  type        = string
-  description = "Private operations subnet prefix."
-  default     = ""
-}
-
-variable "public_mssql_databases_subnet" {
-  type        = string
-  description = "Public MSSQL subnet prefix."
-  default     = ""
-}
-
-variable "private_databases_subnet" {
-  type        = string
-  description = "Private databases subnet prefix."
-  default     = ""
 }
 
 variable "subscription_id" {


### PR DESCRIPTION
## Summary
- drop unused VPN and subnet variables from the `arbit_workflow` module
- remove the matching module inputs, variable declarations, and tfvars entries from each environment

## Testing
- terraform fmt (dev) *(fails: terraform not installed)*
- terraform fmt (qa) *(fails: terraform not installed)*
- terraform fmt (stage) *(fails: terraform not installed)*
- terraform fmt (prod) *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7052443883268593744e6fcde51f